### PR TITLE
Coverage improvements

### DIFF
--- a/src/main/scala/chiselverify/coverage/package.scala
+++ b/src/main/scala/chiselverify/coverage/package.scala
@@ -37,8 +37,12 @@ package object coverage {
     class CoverageCollector {
         private val reports = mutable.ArrayBuffer[CoverageReport]()
 
-        def collect(groupReport: GroupReport): Unit = {
+        def collect(groupReport: CoverageReport): Unit = {
             reports += groupReport
+        }
+
+        def report: String = {
+            reports.reduce(_ + _).serialize
         }
     }
 

--- a/src/main/scala/chiselverify/coverage/package.scala
+++ b/src/main/scala/chiselverify/coverage/package.scala
@@ -380,7 +380,7 @@ package object coverage {
       * @param range the actual scala range
       */
     case class Bins(name: String, range: Range) {
-        def ==(that: Bins): Boolean = (name == that.name) && (range.start == that.range.start) && (range.end == that.range.`end`)
+        def ==(that: Bins): Boolean = (name == that.name) && (range.start == that.range.start) && (range.end == that.range.end)
     }
 
     /**

--- a/src/main/scala/chiselverify/coverage/package.scala
+++ b/src/main/scala/chiselverify/coverage/package.scala
@@ -394,8 +394,8 @@ package object coverage {
         val bin2Name : String = s"${name}_2"
 
          def ==(that: CrossBin): Boolean = (name == that.name) &&
-            (range1.start == that.range1.start) && (range1.end == that.range2.`end`) &&
-            (range2.start == that.range1.start) && (range2.end == that.range2.`end`)
+            (range1.start == that.range1.start) && (range1.end == that.range1.end) &&
+            (range2.start == that.range2.start) && (range2.end == that.range2.end)
     }
 
     /**

--- a/src/main/scala/chiselverify/coverage/package.scala
+++ b/src/main/scala/chiselverify/coverage/package.scala
@@ -214,7 +214,9 @@ package object coverage {
       * @param nHits the number of hits sampled for this bin during the test suite
       */
     case class BinReport(bin: Bins, nHits: BigInt) extends Report {
-        override def report: String = s"BIN ${bin.name} COVERING ${bin.range.toString} HAS $nHits HIT(S)"
+        private val proportion = nHits.toInt / bin.range.size.toDouble
+        private val percentage = f"${if (proportion > 1) 100 else proportion * 100}%1.2f"
+        override def report: String = s"BIN ${bin.name} COVERING ${bin.range.toString} HAS $nHits HIT(S) = ${percentage}%"
 
         override def equals(that: Any): Boolean = {
             that match {
@@ -235,8 +237,10 @@ package object coverage {
       * @param nHits the number of hits sampled for this cross bin during the test suite
       */
     case class CrossBinReport(crossBin: CrossBin, nHits: BigInt) extends Report {
+        private val proportion = nHits.toInt / (crossBin.range1.size * crossBin.range2.size).toDouble
+        private val percentage = f"${if (proportion > 1) 100 else proportion * 100}%1.2f"
         override def report: String =
-            s"BIN ${crossBin.name} COVERING ${crossBin.range1.toString} CROSS ${crossBin.range2.toString} HAS $nHits HIT(S)"
+            s"BIN ${crossBin.name} COVERING ${crossBin.range1.toString} CROSS ${crossBin.range2.toString} HAS $nHits HIT(S) = ${percentage}%"
 
         override def equals(that: Any): Boolean = {
             that match {

--- a/src/main/scala/examples/leros/AluAccuMultiIO.scala
+++ b/src/main/scala/examples/leros/AluAccuMultiIO.scala
@@ -1,0 +1,68 @@
+package examples.leros
+
+import chisel3._
+import chisel3.util._
+import examples.leros.Types.{add, and, ld, nop, or, shr, sub, xor}
+
+class AluAccuInput(val size: Int) extends Bundle{
+  val op = UInt(3.W)
+  val din = UInt(size.W)
+  val ena = Bool()
+}
+
+class AluAccuOutput(val size: Int) extends Bundle {
+  val accu = UInt(size.W)
+}
+
+/**
+  * Base class for Leros ALU including the accumulator register.
+  *
+  * @param size
+  */
+abstract class AluAccuMutliIO(sizen: Int) extends MultiIOModule {
+  val input = IO(Input(new AluAccuInput(sizen)))
+  val output = IO(Output(new AluAccuOutput(sizen)))
+}
+
+class AluAccuMultiChisel(val size: Int) extends AluAccuMutliIO(size) {
+
+  val accuReg = RegInit(0.U(size.W))
+
+  val op = input.op
+  val a = accuReg
+  val b = input.din
+  val res = WireDefault(a)
+
+  switch(op) {
+    is(nop) {
+      res := a
+    }
+    is(add) {
+      res := a + b
+    }
+    is(sub) {
+      res := a - b
+    }
+    is(and) {
+      res := a & b
+    }
+    is(or) {
+      res := a | b
+    }
+    is(xor) {
+      res := a ^ b
+    }
+    is (shr) {
+      res := a >> 1
+    }
+    is(ld) {
+      res := b
+    }
+  }
+
+  when (input.ena) {
+    accuReg := res
+  }
+
+  output.accu := accuReg
+}

--- a/src/test/scala/examples/leros/AluVerification.scala
+++ b/src/test/scala/examples/leros/AluVerification.scala
@@ -1,0 +1,194 @@
+package examples.leros
+
+import chisel3._
+import chisel3.experimental.BundleLiterals.AddBundleLiteralConstructor
+import chisel3.tester._
+import chiseltest.ChiselScalatestTester
+import chiselverify.coverage.{Bins, CoverPoint, CoverageCollector, CoverageReporter, CrossBin, CrossPoint}
+import chiselverify.crv.{RangeBinder, ValueBinder}
+import chiselverify.crv.backends.jacop._
+import org.scalatest.{BeforeAndAfterAll, FlatSpec}
+
+import scala.math.pow
+
+case class AluAccumulator(value: BigInt)
+
+class AluTransaction(seed: Int, size: Int) extends RandObj {
+  currentModel = new Model(seed)
+  val max = pow(2, size).toInt
+
+  val op = new Rand("op", 0, 7)
+  val din = new Rand("din", 0, max)
+  val ena = new Rand("ena", 0, 1)
+
+  val values = din dist (
+    0 to 0xF := 1,
+    0xF to 0xFF := 1,
+    0xFF to 0xFFF := 1,
+    0xFFF to 0xFFFF := 1,
+  )
+
+  val onlyHigh = din dist (
+    0xFF to 0xFFF := 1,
+    0xFFF to 0xFFFF := 10,
+  )
+
+  val enaHigh = ena dist (
+    1 := 99,
+    0 := 1
+  )
+
+  onlyHigh.disable()
+
+  def toBundle: AluAccuInput = {
+    new AluAccuInput(size).Lit(_.op -> op.value().U, _.din -> din.value().U, _.ena -> ena.value().B)
+  }
+}
+
+object AluGoldenModel {
+
+  def genNextState(transaction: AluAccuInput, accu: AluAccumulator): AluAccumulator = {
+    val mask: Int = (1 << transaction.din.getWidth) - 1
+    if (transaction.ena.litToBoolean) {
+      transaction.op.litValue().toInt match {
+        case 0 => accu
+        case 1 => if ((accu.value + transaction.din.litValue()) > mask) {
+          AluAccumulator((accu.value + transaction.din.litValue()) & mask)
+        } else {
+          AluAccumulator(accu.value + transaction.din.litValue())
+        }
+        case 2 => if ((accu.value - transaction.din.litValue()) < 0) {
+          AluAccumulator((accu.value - transaction.din.litValue()) & mask)
+        } else {
+          AluAccumulator(accu.value - transaction.din.litValue())
+        }
+        case 3 => AluAccumulator(accu.value & transaction.din.litValue())
+        case 4 => AluAccumulator(accu.value | transaction.din.litValue())
+        case 5 => AluAccumulator(accu.value ^ transaction.din.litValue)
+        case 6 => AluAccumulator(transaction.din.litValue())
+        case 7 => AluAccumulator(accu.value.toInt >>> 1)
+      }
+    } else {
+      accu
+    }
+  }
+
+  def genOutputStates(listT: List[AluAccuInput], accu: AluAccumulator): List[AluAccumulator] = {
+    listT match {
+      case Nil => Nil
+      case x :: xs =>
+        val nexAccu = genNextState(x, accu)
+        nexAccu :: genOutputStates(xs, nexAccu)
+    }
+  }
+
+  def serializeAccu(accu: AluAccumulator, size: Int): AluAccuOutput =
+    new AluAccuOutput(size).Lit(_.accu -> accu.value.U)
+
+  def generateAluAccuTransactions(listT: List[AluAccuInput], accu: AluAccumulator): List[AluAccuOutput] = {
+    genOutputStates(listT, accu).map(serializeAccu(_, listT.head.din.getWidth))
+  }
+
+  def compareSingle(transaction: (AluAccuOutput, AluAccuOutput)): Boolean = {
+    val (dutT, genT) = transaction
+     equals(dutT.accu.litValue() == genT.accu.litValue())
+    dutT.accu.litValue() == genT.accu.litValue()
+  }
+
+  def compare(transactions: List[(AluAccuOutput, AluAccuOutput)]): List[Boolean] = {
+    transactions map compareSingle
+  }
+}
+
+trait AluBehavior {
+  this: FlatSpec with ChiselScalatestTester =>
+  val coverageCollector = new CoverageCollector
+
+  def compute(name: String, size: Int, inputT: List[AluAccuInput]): Unit = {
+    it should s"test alu with $name" in {
+      test(new AluAccuMultiChisel(size)) { dut =>
+        val cr = new CoverageReporter(dut)
+        cr.register(
+          List(
+          CoverPoint(dut.input.op , "op")(
+            List(
+              Bins("nop", 0 to 0), Bins("add", 1 to 1),
+              Bins("sub", 2 to 2), Bins("and", 3 to 3),
+              Bins("or", 4 to 4), Bins("xor", 5 to 5),
+              Bins("ld", 6 to 6), Bins("shr", 7 to 7))),
+          CoverPoint(dut.input.din, "din")(
+            List(
+              Bins("0xF", 0 to 0xF), Bins("0xFF", 0xF to 0xFF),
+              Bins("0xFFF", 0xFF to 0xFFF), Bins("0xFFFF", 0xFFF to 0xFFFF),
+            )
+          ),
+            CoverPoint(dut.output.accu, "accu")(
+              List(
+                Bins("0xF", 0 to 0xF), Bins("0xFF", 0xF to 0xFF),
+                Bins("0xFFF", 0xFF to 0xFFF), Bins("0xFFFF", 0xFFF to 0xFFFF),
+              )
+            ),
+            CoverPoint(dut.input.ena, "ena")(
+              List(
+                Bins("disabled", 0 to 0),
+                Bins("enabled", 1 to 1)
+              )
+            )), List(
+            CrossPoint("operations cross enable", "op", "ena")(
+              List(
+                CrossBin("operation enable", 0 to 7, 1 to 1),
+                CrossBin("operation disabled", 0 to 7, 0 to 0),
+            )))
+        )
+
+        val computedTransactions: List[AluAccuOutput] = inputT.map { T =>
+          dut.input.poke(T)
+          dut.clock.step()
+          cr.sample()
+          dut.output.peek
+        }
+
+        val goldenTransactions = AluGoldenModel.generateAluAccuTransactions(inputT, AluAccumulator(0))
+        AluGoldenModel.compare(computedTransactions zip goldenTransactions)
+        coverageCollector.collect(cr.report)
+      }
+    }
+  }
+}
+
+class AluVerification extends FlatSpec with AluBehavior with ChiselScalatestTester with BeforeAndAfterAll {
+  behavior of "AluAccumulator"
+  val size = 16
+  val tnumber = 5000
+  val seeds = List(30, 104 , 60, 90, 200, 50, 22, 2000, 40, 900, 70, 23)
+
+  println(s"Testing ALU with ${tnumber * seeds.size * 2} random transactions")
+  // General test
+  seeds.map { seed =>
+    val length = tnumber
+    val masterT = new AluTransaction(seed, size)
+    val transactions: Seq[AluAccuInput] = (0 to length) map { _ =>
+      masterT.randomize
+      masterT.toBundle
+    }
+    it should behave like compute(s"seed = $seed, and normal values", size, transactions.toList)
+  }
+
+  // Only transactions with values between 0xFF to 0xFFFF
+  seeds.map { seed =>
+    val length = tnumber
+    val masterT = new AluTransaction(seed, size)
+    val onlyHighTransactions: Seq[AluAccuInput] = (0 to length) map { _ =>
+      masterT.onlyHigh.enable()
+      masterT.values.disable()
+      masterT.randomize
+      masterT.toBundle
+    }
+    it should behave like compute(s"seed = $seed, and high values", size, onlyHighTransactions.toList)
+  }
+
+
+  override def afterAll(): Unit = {
+    println(coverageCollector.report)
+  }
+}


### PR DESCRIPTION
With this PR, I want to improve the coverage report generated by the `CoverageReporter` class. At the end of the test suite run, I would like to know the total coverage percentage for each CoverGroups. So I would like to have a complete report for all the tests declared inside a test suite and not only partial reports for each test.

Unfortunately, the `CoverageReporter` needs a reference to the device under test for the time coverage functionality. Instead of modifying this class, I decided to create a `CoverageCollector` type that collects partial `GroupReports `and then displays the total result at the end of all the tests present in one test suite.

To sum the results of each partial test, I've added a `+` method to all the `Report` classes. An addition between two reports only works if the two have the same number of Bins and the same name (basically if the two reports are the same). This definition of addition is probably not the best one. Still, it is better than having to manually collect and sum the output of each test. I've also added the percentage of coverage for each coverage report.  So now it prints something like:
```
BIN insertion lower half COVERING Range 0 to 0 CROSS Range 0 to 127 HAS 12 HIT(S) = 9.38%
```
A better approach than summing reports would be decoupling the `CoverageDatabase` from the `CoverageReporter` and pass the database to each test and print the report from the database.  But this will require some changes for how the `CoverGroups` are handled right @Dobios ?

I've also added a new MultiIO Leros ALU to demonstrate how I think CRV and Functional Coverage should be used in Chisel. 