### PR TITLE
Cover Conditionals

### DIFF
--- a/src/main/scala/chiselverify/coverage/CoverageReporter.scala
+++ b/src/main/scala/chiselverify/coverage/CoverageReporter.scala
@@ -37,8 +37,7 @@ class CoverageReporter[T <: MultiIOModule](private val dut: T) {
         coverGroups.map(g =>
             GroupReport(
                 g.id,
-                g.points.map(p =>
-                    PointReport(p.portName, p.bins.map(b => BinReport(b, coverageDB.getNHits(p.portName, b.name))))),
+                g.points.map(_.report(coverageDB)),
                 g.crosses.map {
                     case t: TimedCross =>
                         //Sanity check
@@ -112,7 +111,7 @@ class CoverageReporter[T <: MultiIOModule](private val dut: T) {
     def sample(): Unit = {
 
         coverGroups foreach(group => {
-            var sampledPoints: List[CoverPoint] = Nil
+            var sampledPoints: List[Cover] = Nil
 
             //Sample cross points
             group.crosses.foreach(cross => {
@@ -131,8 +130,7 @@ class CoverageReporter[T <: MultiIOModule](private val dut: T) {
                     sampledPoints = sampledPoints :+ point
 
                     //Check for the ports & sample all bins
-                    val pointVal = point.port.peek().asUInt().litValue().toInt
-                    point.bins.foreach(_.sample(point.portName, pointVal, coverageDB))
+                    point.sample(coverageDB)
                 }
             })
         })

--- a/src/main/scala/chiselverify/coverage/CoverageReporter.scala
+++ b/src/main/scala/chiselverify/coverage/CoverageReporter.scala
@@ -142,12 +142,12 @@ class CoverageReporter[T <: MultiIOModule](private val dut: T) {
       *               These are defined by (portName: String, bins: List[BinSpec])
       * @return the unique ID attributed to the group
       */
-    def register(points: List[CoverPoint], crosses: List[Cross] = Nil): CoverGroup = {
+    def register(points: List[Cover], crosses: List[Cross] = Nil): CoverGroup = {
         //Generate the group's identifier
         val gid: BigInt = coverageDB.createCoverGroup()
 
         //Register coverpoints
-        points foreach (p => coverageDB.registerCoverPoint(p.portName, p))
+        points foreach (p => p.register(coverageDB))
         crosses foreach (c => c.register(coverageDB))
 
         //Create final coverGroup

--- a/src/main/scala/chiselverify/coverage/Utils.scala
+++ b/src/main/scala/chiselverify/coverage/Utils.scala
@@ -68,4 +68,19 @@ object Utils {
             }
         }
     }
+
+    //Hardcoded cartesian for better performance
+    def cartesian(ranges: List[List[Int]]): List[List[Int]] = ranges.length match {
+        case 1 => ranges
+        case 2 => for (r1 <- ranges.head; r2 <- ranges.tail.head) yield List(r1, r2)
+        case 3 => for (x1 <- ranges.head; x2 <- ranges.tail.head; x3 <- ranges.tail.tail.head)
+            yield List(x1, x2, x3)
+        case 4 => for {
+            x1 <- ranges.head
+            x2 <- ranges.tail.head
+            x3 <- ranges.tail.tail.head
+            x4 <- ranges.tail.tail.tail.head
+        } yield List(x1, x2, x3, x4)
+        case _ => throw new IllegalArgumentException("MAX ARRAY SIZE IN CARTESIAN PRODUCT IS 4")
+    }
 }

--- a/src/main/scala/chiselverify/coverage/Utils.scala
+++ b/src/main/scala/chiselverify/coverage/Utils.scala
@@ -1,0 +1,71 @@
+/**
+  * Code taken from https://gist.github.com/kylewlacy/38681caaee2b98949dd8
+  * @author Kyle Lacy (username: @kylewlacy)
+  */
+
+package chiselverify.coverage
+import scala.reflect.ClassTag
+
+object Utils {
+    /**
+      * Given an List containing a partial Cartesian product, and an List of
+      * items, return an List adding the list of items to the partial
+      * Cartesian product.
+      *
+      * {{{
+      * val partialProduct = List(List(1, 4), List(1, 5), List(2, 4), List(2, 5))
+      * val items = List(6, 7)
+      * partialCartesian(partialProduct, items) ==
+      * List(List(1, 4, 6),
+      *       List(1, 4, 7),
+      *       List(1, 5, 6),
+      *       List(1, 5, 7),
+      *       List(2, 4, 6),
+      *       List(2, 4, 7),
+      *       List(2, 5, 6),
+      *       List(2, 5, 7))
+      * }}}
+      */
+    private def partialCartesian[T: ClassTag](a: List[List[T]], b: List[T]):
+    List[List[T]] = {
+        a.flatMap(xs => {
+            b.map(y => {
+                xs ++ List(y)
+            })
+        })
+    }
+
+    /**
+      * Computes the Cartesian product of lists[0] * lists[1] * ... * lists[n].
+      *
+      * {{{
+      * scala> import CartesianProduct._
+      * scala> val lists = List(List(1, 2), List(4, 5), List(6, 7));
+      * scala> cartesianProduct(lists)
+      * scala> cartesianProduct(lists)
+      * res0: List[List[Int]] = List(List(1, 4, 6),
+      *                                 List(1, 4, 7),
+      *                                 List(1, 5, 6),
+      *                                 List(1, 5, 7),
+      *                                 List(2, 4, 6),
+      *                                 List(2, 4, 7),
+      *                                 List(2, 5, 6),
+      *                                 List(2, 5, 7))
+      * }}}
+      */
+    def cartesianProduct[T: ClassTag](lists: List[List[T]]): List[List[T]] = {
+        lists.headOption match {
+            case Some(head) => {
+                val tail = lists.tail
+                val init = head.map(n => List(n))
+
+                tail.foldLeft(init)((arr, list) => {
+                    partialCartesian(arr, list)
+                })
+            }
+            case None => {
+                Nil
+            }
+        }
+    }
+}

--- a/src/main/scala/chiselverify/coverage/package.scala
+++ b/src/main/scala/chiselverify/coverage/package.scala
@@ -29,6 +29,7 @@ package object coverage {
     abstract class Report {
         /**
           * Generates a part of or the entirety of the coverage report
+          *
           * @return a string containing the coverage report
           */
         def report: String
@@ -45,6 +46,7 @@ package object coverage {
 
         /**
           * Adds two different reports of the same type together
+          *
           * @param that an other report of the same type as this one
           * @return a concatenated version of the two reports
           */
@@ -52,6 +54,7 @@ package object coverage {
     }
 
     def sortByName(a: Report, b: Report): Boolean = a.name > b.name
+
     def sortById(a: Report, b: Report): Boolean = a.id > b.id
 
     class CoverageCollector {
@@ -68,6 +71,7 @@ package object coverage {
 
     /**
       * General data class containing the coverage report
+      *
       * @param groups the list of group reports
       */
     case class CoverageReport(groups: List[Report]) extends Serializable {
@@ -76,19 +80,20 @@ package object coverage {
           */
         def serialize: String = {
             val rep = new StringBuilder(s"\n============ COVERAGE REPORT ============\n")
-            groups foreach(group => rep append s"${group.report}")
+            groups foreach (group => rep append s"${group.report}")
             rep append "=========================================\n"
             rep.mkString
         }
 
         /**
           * Traverses the report tree to find the given bin (if any)
-          * @param groupId the id of the group containing the bin
+          *
+          * @param groupId   the id of the group containing the bin
           * @param pointName the name the point that contains the bin
-          * @param binName the name of the bin itself
+          * @param binName   the name of the bin itself
           * @return
           */
-        def binNHits(groupId: BigInt, pointName: String, binName: String) : BigInt = {
+        def binNHits(groupId: BigInt, pointName: String, binName: String): BigInt = {
             //Look for the group
             groups.find(_.id == groupId) match {
                 case None => throw new IllegalArgumentException(s"No group with ID $groupId!!")
@@ -130,6 +135,7 @@ package object coverage {
                 }
             }
         }
+
         override def equals(that: Any): Boolean = that match {
             case CoverageReport(g) => g.sortWith(sortById) == groups.sortWith(sortById)
             case _ => false
@@ -137,14 +143,15 @@ package object coverage {
 
         def +(that: CoverageReport): CoverageReport = {
             require(this == that)
-            CoverageReport((that.groups zip groups).map{case(g1, g2) => g1 + g2})
+            CoverageReport((that.groups zip groups).map { case (g1, g2) => g1 + g2 })
         }
     }
 
     /**
       * Contains the coverage report info for a given cover group
-      * @param id the id of the group
-      * @param points the list of reports for the coverpoints contained in this group
+      *
+      * @param id      the id of the group
+      * @param points  the list of reports for the coverpoints contained in this group
       * @param crosses the list of reports for the crosspoints contained in this group
       */
     case class GroupReport(id: BigInt, points: List[Report] = Nil, crosses: List[Report] = Nil) extends Report {
@@ -164,8 +171,8 @@ package object coverage {
         override def +(that: Report): Report = that match {
             case GroupReport(_, tpoints, tcrosses) =>
                 require(this == that)
-                val newPoints: List[Report] = (tpoints zip points).map{ case(p1, p2) => p1 + p2 }
-                val newCrosses = (tcrosses zip crosses).map{case(c1, c2) => c1 + c2}
+                val newPoints: List[Report] = (tpoints zip points).map { case (p1, p2) => p1 + p2 }
+                val newCrosses = (tcrosses zip crosses).map { case (c1, c2) => c1 + c2 }
                 GroupReport(id, newPoints, newCrosses)
 
             case _ => throw new IllegalArgumentException("Argument must be of type GroupReport")
@@ -177,8 +184,27 @@ package object coverage {
         override val name: String = s"$id"
     }
 
+    case class ConditionReport(name: String, conds: List[Report]) extends Report {
+        override def report: String = {
+            val rep = new StringBuilder(s"COVER_CONDITION NAME: $name")
+            ???
+        }
+
+        override def +(that: Report): Report = that match {
+            case ConditionReport(_, tconds) =>
+                require(this == that)
+                val newPoints = (conds zip tconds).map { case (b1, b2) => b1 + b2 }
+                ConditionReport(name, newPoints)
+
+            case _ => throw new IllegalArgumentException("Argument must be of type ConditionReport")
+        }
+
+        override val id: BigInt = name.hashCode
+    }
+
     /**
       * Contains the coverage report info for a given cover point
+      *
       * @param name the name of the cover point
       * @param bins the list of reports related to the bins of the current cover point
       */
@@ -197,7 +223,7 @@ package object coverage {
         override def +(that: Report): Report = that match {
             case PointReport(_, tbins) =>
                 require(this == that)
-                val newPoints = (bins zip tbins).map{case(b1, b2) => b1 + b2}
+                val newPoints = (bins zip tbins).map { case (b1, b2) => b1 + b2 }
                 PointReport(name, newPoints)
 
             case _ => throw new IllegalArgumentException("Argument must be of type PointReport")
@@ -208,8 +234,9 @@ package object coverage {
 
     /**
       * Contains the coverage report info for a given cross point
+      *
       * @param cross a reference to the cross point for which we are generating a report
-      * @param bins the list of reports related to the bins of the current cross point
+      * @param bins  the list of reports related to the bins of the current cross point
       */
     case class CrossReport(cross: Cross, bins: List[Report], delay: DelayType = NoDelay) extends Report {
         override def report: String = {
@@ -228,7 +255,7 @@ package object coverage {
         def +(that: Report): Report = that match {
             case CrossReport(_, tbins, _) =>
                 require(this == that)
-                val newBins = (bins zip tbins).map{case(b1, b2) => b1 + b2}
+                val newBins = (bins zip tbins).map { case (b1, b2) => b1 + b2 }
                 CrossReport(cross, newBins, delay)
             case _ => throw new IllegalArgumentException("Argument must be of type CrossReport")
         }
@@ -239,13 +266,17 @@ package object coverage {
 
     /**
       * Contains the coverage report info for a given cover point bin
-      * @param bin a reference to the bin for which we are generating a report
+      *
+      * @param bin   a reference to the bin for which we are generating a report
       * @param nHits the number of hits sampled for this bin during the test suite
       */
     case class BinReport(bin: Bins, nHits: BigInt) extends Report {
         private val proportion = nHits.toInt / bin.range.size.toDouble
         private val percentage = f"${if (proportion > 1) 100 else proportion * 100}%1.2f"
-        override def report: String = s"BIN ${bin.name} COVERING ${bin.range.toString} HAS $nHits HIT(S) = $percentage%"
+
+        override def report: String = s"BIN ${bin.name} COVERING ${bin.range.toString}" +
+            s"${if (bin.condition != ((_: BigInt) => true)) s"WITH CONDITION ${bin.condition}" else ""}" +
+            s"HAS $nHits HIT(S) = $percentage%"
 
         override def equals(that: Any): Boolean = that match {
             case BinReport(b, _) => b == bin
@@ -265,12 +296,14 @@ package object coverage {
 
     /**
       * Contains the coverage report info for a given cross point bin
+      *
       * @param crossBin a reference to the cross bin for which we are generating a report
-      * @param nHits the number of hits sampled for this cross bin during the test suite
+      * @param nHits    the number of hits sampled for this cross bin during the test suite
       */
     case class CrossBinReport(crossBin: CrossBin, nHits: BigInt) extends Report {
         private val proportion = nHits.toInt / (crossBin.range1.size * crossBin.range2.size).toDouble
         private val percentage = f"${if (proportion > 1) 100 else proportion * 100}%1.2f"
+
         override def report: String =
             s"BIN ${crossBin.name} COVERING ${crossBin.range1.toString} CROSS ${crossBin.range2.toString} HAS $nHits HIT(S) = $percentage%"
 
@@ -293,41 +326,63 @@ package object coverage {
 
     /**
       * Represents a group of cover points that will be sampled simultaneously
-      * @param id a unique identifier for the group
-      * @param points the cover points that are grouped together
+      *
+      * @param id      a unique identifier for the group
+      * @param points  the cover points that are grouped together
       * @param crosses the cross points contained in the group
       */
     case class CoverGroup(id: BigInt, points: List[Cover], crosses: List[Cross])
 
-    abstract class Cover(val port: Data, val portName: String) {
+    abstract class Cover(val ports: List[Data], val portName: String) {
         override def toString: String = serialize
 
         /**
           * Generates a report in a form that is compatible with the coverage reporter
+          *
           * @return a Report
           */
         def report(db: CoverageDB): Report
 
         /**
           * Converts the current cover construct into a human-readable string
+          *
           * @return a String representing the cover construct
           */
         def serialize: String
 
         /**
           * Samples the current cover construct
+          *
           * @param db the coverage DataBase we are sampling in
           */
         def sample(db: CoverageDB): Unit
     }
 
+    case class Condition(name: String, cond: List[BigInt] => Boolean) {
+        def apply(args: List[BigInt]): Boolean = cond(args)
+    }
+
+    case class CoverCondition(p: List[Data], pN: String)(val conds: List[Condition])
+        extends Cover(p, pN) {
+        override def report(db: CoverageDB): Report = ???
+
+        override def serialize: String = s"CoverCondition($ports, $portName)($conds)"
+
+        override def sample(db: CoverageDB): Unit = {
+            val pointVals = ports.map(_.peek().asUInt().litValue())
+            db.addConditionalHit(portName, conds.filter(c => c(pointVals)).map(_.name))
+        }
+    }
+
     /**
       * Represents a single cover point that samples a given dut port
-      * @param p the DUT port that will be sampled for this point
-      * @param pN the name that will be used to represent the point in the report
+      *
+      * @param p    the DUT port that will be sampled for this point
+      * @param pN   the name that will be used to represent the point in the report
       * @param bins the list of value ranges that will be checked for for the given port
       */
-    case class CoverPoint(p: Data, pN: String)(val bins: List[Bins] = List(DefaultBin(p))) extends Cover(p, pN) {
+    case class CoverPoint(port: Data, pN: String)(val bins: List[Bins] = List(DefaultBin(port)))
+        extends Cover(port::Nil, pN) {
 
         override def serialize: String = s"CoverPoint($port, $portName)(${bins.map(_.serialize)})"
 
@@ -337,11 +392,6 @@ package object coverage {
             bins.foreach(_.sample(portName, pointVal, db))
         }
 
-        /**
-          * Generates a report in a form that is compatible with the coverage reporter
-          *
-          * @return a Report
-          */
         override def report(db: CoverageDB): Report =
             PointReport(portName, bins.map(b => BinReport(b, db.getNHits(portName, b.name))))
     }
@@ -350,13 +400,15 @@ package object coverage {
 
         /**
           * Samples the current cross relation using a given database
+          *
           * @param db the current database used throughout the test suits
           * @return the two points that were sampled during this cross sampling
           */
-        def sample(db: CoverageDB): Option[(CoverPoint, CoverPoint)]
+        def sample(db: CoverageDB): Option[(Cover, Cover)]
 
         /**
           * Registers the current cross point with the given coverage DB
+          *
           * @param db the database used for the current test suite
           */
         def register(db: CoverageDB): Unit
@@ -364,37 +416,38 @@ package object coverage {
 
     /**
       * Represents a coverage relation between two different DUT ports
-      * @param name the name that will be used to represent the relation in the report 
+      *
+      * @param name       the name that will be used to represent the relation in the report
       * @param pointName1 the first point of the relation
       * @param pointName2 the other point in the relation
-      * @param bins the list of value ranges that will be checked for for the given relation
+      * @param bins       the list of value ranges that will be checked for for the given relation
       */
     case class CrossPoint(override val name: String, override val pointName1: String, override val pointName2: String)(override val bins: List[CrossBin])
         extends Cross(name, pointName1, pointName2, bins) {
 
-        override def sample(db: CoverageDB) : Option[(CoverPoint, CoverPoint)] = {
+        override def sample(db: CoverageDB): Option[(Cover, Cover)] = {
 
-            def sampleBins(point: CoverPoint, value: Int) : Unit =
-                point.bins.foreach(bin => bin.sample(point.portName, value, db))
+            db.getPointsFromCross(this) match {
+                case (point1: CoverPoint, point2: CoverPoint) =>
+                    val pointVal1 = point1.port.peek().asUInt().litValue()
+                    val pointVal2 = point2.port.peek().asUInt().litValue()
 
-            val (point1, point2) = db.getPointsFromCross(this)
-            val pointVal1 = point1.port.peek().asUInt().litValue()
-            val pointVal2 = point2.port.peek().asUInt().litValue()
+                    //Sample the points individually first
+                    point1.sample(db)
+                    point2.sample(db)
 
-            //Sample the points individually first
-            sampleBins(point1, pointVal1.toInt)
-            sampleBins(point2, pointVal2.toInt)
+                    //Sample the cross bins
+                    bins.foreach(cb => {
+                        if ((cb.range1 contains pointVal1) && (cb.range2 contains pointVal2)) {
+                            db.addCrossBinHit(cb, (pointVal1, pointVal2))
+                        }
+                    })
 
-            //Sample the cross bins
-            bins.foreach(cb => {
-                if((cb.range1 contains pointVal1) && (cb.range2 contains pointVal2)) {
-                    db.addCrossBinHit(cb, (pointVal1, pointVal2))
-                }
-            })
+                    Some(point1, point2)
 
-            Some(point1, point2)
+                case _ => None
+            }
         }
-
 
         override def register(db: CoverageDB): Unit = db.registerCross(this)
     }
@@ -402,44 +455,48 @@ package object coverage {
     /**
       * A timed version of a cross point. This means that, given a delay, point 2 will be sampled a certain amount of 
       * cycles after point 1.
-      * @param name the name of the cross, used for the report
-      * @param delay the number of cycles between sampling point1 and point2
+      *
+      * @param name       the name of the cross, used for the report
+      * @param delay      the number of cycles between sampling point1 and point2
       * @param pointName1 the first point that will be sampled
       * @param pointName2 the point that will be sampled ${delay} cycles after point1 
-      * @param bins the list of value ranges that will be checked for for the given relation
+      * @param bins       the list of value ranges that will be checked for for the given relation
       */
     case class TimedCross(override val name: String, override val pointName1: String, override val pointName2: String,
-          delay: DelayType)(override val bins: List[CrossBin]) extends Cross(name, pointName1, pointName2, bins) {
-        private var initCycle : Option[BigInt] = None
+                          delay: DelayType)(override val bins: List[CrossBin]) extends Cross(name, pointName1, pointName2, bins) {
+        private var initCycle: Option[BigInt] = None
 
         override def sample(db: CoverageDB): Option[(CoverPoint, CoverPoint)] = {
             //Sanity check
-            if(initCycle.isEmpty) throw new IllegalStateException("Timed relation hasn't been registered!")
+            if (initCycle.isEmpty) throw new IllegalStateException("Timed relation hasn't been registered!")
 
-            def sampleBins(portNames: (String, String), tBins: List[CrossBin], values: (BigInt, BigInt), cycle: BigInt) : Unit =
+            def sampleBins(portNames: (String, String), tBins: List[CrossBin], values: (BigInt, BigInt), cycle: BigInt): Unit =
                 tBins.foreach(tBin => {
-                    if(tBin.range1 contains values._1) {
+                    if (tBin.range1 contains values._1) {
                         db.addTimedBinHit(portNames._1, tBin.bin1Name, values._1, cycle)
                     }
 
-                    if(tBin.range2 contains values._2) {
+                    if (tBin.range2 contains values._2) {
                         db.addTimedBinHit(portNames._2, tBin.bin2Name, values._2, cycle)
                     }
                 })
 
-            val (point1, point2) = db.getPointsFromCross(this)
-            val pointVal1 = point1.port.peek().asUInt().litValue()
-            val pointVal2 = point2.port.peek().asUInt().litValue()
+            db.getPointsFromCross(this) match {
+                case (point1: CoverPoint, point2: CoverPoint) =>
+                    val pointVal1 = point1.port.peek().asUInt().litValue()
+                    val pointVal2 = point2.port.peek().asUInt().litValue()
 
-            //Sample the points at the current cycle
-            val curCycle = db.getCurCycle
-            sampleBins((point1.portName, point2.portName), bins, (pointVal1, pointVal2), curCycle)
+                    //Sample the points at the current cycle
+                    val curCycle = db.getCurCycle
+                    sampleBins((point1.portName, point2.portName), bins, (pointVal1, pointVal2), curCycle)
+            }
 
             None
         }
 
         /**
           * Registers the cross relation with the db and schedules the second point
+          *
           * @param db the database used for the current test suite
           */
         override def register(db: CoverageDB): Unit = {
@@ -453,30 +510,48 @@ package object coverage {
 
     /**
       * A value range that will be used for sampling
-      * @param name the name of the value range that will be used to represent it in the report
-      * @param range the actual scala range
+      *
+      * @param name      the name of the value range that will be used to represent it in the report
+      * @param range     the actual scala range
       * @param condition an extra condition that can be used to consider a hit
       */
-    case class Bins(name: String, range: Range, condition: () => Boolean = () => true) {
-        def ==(that: Bins): Boolean = (name == that.name) && (range.start == that.range.start) && (range.end == that.range.end)
+    class Bins(val name: String, val rangeOpt: Option[Range], val condition: (BigInt) => Boolean = _ => true) {
+        def ==(that: Bins): Boolean = {
+            val r = rangeOpt.getOrElse(0 to 0)
+            val thatR = that.rangeOpt.getOrElse(0 to 0)
+            (name == that.name) && (r.start == thatR.start) && (r.end == thatR.end)
+        }
 
-        def sample(portName: String, value: Int, coverageDB: CoverageDB): Unit =
-            if(range.contains(value) && condition()) coverageDB.addBinHit(portName, name, value)
+        def sample(portName: String, value: BigInt, coverageDB: CoverageDB): Unit =
+            if (condition(value)) rangeOpt match {
+                case None => coverageDB.addBinHit(portName, name, value)
+                case Some(r) => if (r.contains(value)) coverageDB.addBinHit(portName, name, value)
+            }
 
-        def serialize: String = s"Bin( $name, $range ${ if(condition != (() => true)) condition })"
+        def range: Range = rangeOpt.getOrElse(0 to 0)
+
+        def serialize: String = s"Bin( $name, ${rangeOpt.getOrElse("")} ${if (condition != ((_: BigInt) => true)) condition})"
     }
+
+    object Bins {
+        def apply(name: String, condition: BigInt => Boolean): Bins = new Bins(name, None, condition)
+        def apply(name: String, range: Range): Bins = new Bins(name, Some(range))
+        def apply(name: String, range: Range, condition: BigInt => Boolean) = new Bins(name, Some(range), condition)
+    }
+
 
     /**
       * A range relation between two different ranges
-      * @param name the name of the relation, used for the report
+      *
+      * @param name   the name of the relation, used for the report
       * @param range1 the range that will be sampled for point1 of the relation
       * @param range2 the range that will be sampled for point2 of the relation
       */
     case class CrossBin(name: String, range1: Range, range2: Range) {
-        val bin1Name : String = s"${name}_1"
-        val bin2Name : String = s"${name}_2"
+        val bin1Name: String = s"${name}_1"
+        val bin2Name: String = s"${name}_2"
 
-         def ==(that: CrossBin): Boolean = (name == that.name) &&
+        def ==(that: CrossBin): Boolean = (name == that.name) &&
             (range1.start == that.range1.start) && (range1.end == that.range1.end) &&
             (range2.start == that.range2.start) && (range2.end == that.range2.end)
     }
@@ -489,6 +564,7 @@ package object coverage {
 
         /**
           * Generates a default bin for a given cover point port
+          *
           * @param port the port for which the bin will be generated
           * @return a bin covering all possible values for a given port
           */
@@ -496,6 +572,7 @@ package object coverage {
 
         /**
           * Generates a default bin for given cross point ports
+          *
           * @param port1 the first point of the cross point
           * @param port2 the second point of the cross point
           * @return a cross bin covering all possible value combinations for the given ports

--- a/src/test/scala/verifyTests/coverage/FunctionalCoverageTest.scala
+++ b/src/test/scala/verifyTests/coverage/FunctionalCoverageTest.scala
@@ -127,6 +127,7 @@ class FunctionalCoverageTest extends FlatSpec with ChiselScalatestTester with Ma
         report.binNHits(1, "aplusb", "default") should be (BigInt(50))
     }
 
+    /** FOR FUTURE TESTING */
     def testDefaultVP[T <: BasicToyDUT](dut: T): Unit = {
         println("TESTING DEFAULT VERIFICATION PLAN")
         val cr = new CoverageReporter(dut)
@@ -243,11 +244,8 @@ class FunctionalCoverageTest extends FlatSpec with ChiselScalatestTester with Ma
     }
 
     "CoverageWithDefaultBins" should "pass" in {
-        test(new BasicToyDUT(32)){
-            dut => {
-                testDefaults(dut)
-                //testDefaultVP(dut)
-            }
+        test(new BasicToyDUT(32)) {
+            dut => testDefaults(dut)
         }
     }
 

--- a/src/test/scala/verifyTests/coverage/FunctionalCoverageTest.scala
+++ b/src/test/scala/verifyTests/coverage/FunctionalCoverageTest.scala
@@ -60,8 +60,9 @@ class FunctionalCoverageTest extends FlatSpec with ChiselScalatestTester with Ma
         cr.register(
             //Declare CoverPoints
             CoverPoint(dut.io.outA , "accu")( //CoverPoint 1
-                Bins("lo10even", 0 until 10, (x: BigInt) => x % 2 == 0)::
-                Bins("First100odd", 0 until 100, (x: BigInt) => x % 2 != 0)::Nil)::
+                Bins("lo10even", 0 until 10, Condition("onlyEven", { case (x:BigInt)::Nil => x % 2 == 0 }))::
+                Bins("First100odd", 0 until 100, Condition("onlyOdd",{ case (x:BigInt)::Nil => x % 2 != 0 }))::
+                Nil)::
             CoverPoint(dut.io.outB, "test")( //CoverPoint 2
                 Bins("testLo10", 0 until 10)::Nil)::
         Nil)
@@ -97,10 +98,10 @@ class FunctionalCoverageTest extends FlatSpec with ChiselScalatestTester with Ma
             //Declare CoverPoints
             CoverCondition(dut.io.outA::dut.io.outB::Nil, "aAndB")(
                 Condition("aeqb", {
-                    case a :: b :: Nil => a == b
-                })::Condition("asuptob", {
+                    case a::b::Nil => a == b
+                })::Condition("asuptobAtLeast100", {
                     case a::b::Nil => a > b
-                })::Nil
+                }, Some(100))::Nil
             )::Nil)
 
         /**
@@ -108,7 +109,7 @@ class FunctionalCoverageTest extends FlatSpec with ChiselScalatestTester with Ma
           */
         def testOne(): Unit = {
             for (fun <- 0 until 100) {
-                dut.io.a.poke(toUInt(fun))
+                dut.io.a.poke(toUInt(fun % 95))
                 dut.io.b.poke(toUInt(fun % 4))
 
                 cr.sample()
@@ -123,7 +124,7 @@ class FunctionalCoverageTest extends FlatSpec with ChiselScalatestTester with Ma
 
         //Check that the number of hits is correct
         report.binNHits(1, "aAndB", "aeqb") should be (BigInt(4))
-        report.binNHits(1, "aAndB", "asuptob") should be (BigInt(96))
+        report.binNHits(1, "aAndB", "asuptobAtLeast100") should be (BigInt(95))
     }
 
 

--- a/src/test/scala/verifyTests/coverage/FunctionalCoverageTest.scala
+++ b/src/test/scala/verifyTests/coverage/FunctionalCoverageTest.scala
@@ -60,8 +60,8 @@ class FunctionalCoverageTest extends FlatSpec with ChiselScalatestTester with Ma
         cr.register(
             //Declare CoverPoints
             CoverPoint(dut.io.outA , "accu")( //CoverPoint 1
-                Bins("lo10even", 0 until 10, () => dut.io.outA.peek().asUInt().litValue() % 2 == 0)::
-                Bins("First100odd", 0 until 100, () => dut.io.outA.peek().asUInt().litValue() % 2 != 0)::Nil)::
+                Bins("lo10even", 0 until 10, (x: BigInt) => x % 2 == 0)::
+                Bins("First100odd", 0 until 100, (x: BigInt) => x % 2 != 0)::Nil)::
             CoverPoint(dut.io.outB, "test")( //CoverPoint 2
                 Bins("testLo10", 0 until 10)::Nil)::
         Nil)


### PR DESCRIPTION
This PR adds the first version of cover conditionals. They can be used as follows:
```scala
CoverCondition(ports: List[Data], readableName: String)(conditions: List[Condition])
//where a condition is
Condition(name: String, func : List[BigInt] => Boolean)
```  
Example:
```scala
val cr = new CoverageReporter(dut)
cr.register(
  //Declare CoverPoints
  CoverCondition(dut.io.outA::dut.io.outB::Nil, "aAndB")(
    Condition("aeqb", {
      case a :: b :: Nil => a == b
    })::Nil
)::Nil)
```
Bins are thus defined using arbitrary functions of the type `List[BigInt] => Boolean` which represent different hit conditions.
No coverage percentage is given due to cartesian product complexity. Instead we offer the possibility to use a user-defined "expected number of Hits" to get a coverage percentage. This looks like the following:
```scala  
val cr = new CoverageReporter(dut)
cr.register(
  //Declare CoverPoints
  CoverCondition(dut.io.outA::dut.io.outB::Nil, "aAndB")(
    Condition("asuptobAtLeast100Times", {
      case a::b::Nil => a > b
  }, Some(100))::Nil
)::Nil)
```  
The above example results in the following coverage report:  
```
============ COVERAGE REPORT ============
============== GROUP ID: 1 ==============
COVER_CONDITION NAME: aAndB
CONDITION aeqb HAS 4 HITS
CONDITION asuptobAtLeast100 HAS 95 HITS EXPECTED 100 = 95.0%
=========================================
=========================================
```