### PR TITLE
Added Timed Operations for Timed Assertions

### DIFF
--- a/src/main/scala/chiselverify/assertions/AssertTimed.scala
+++ b/src/main/scala/chiselverify/assertions/AssertTimed.scala
@@ -18,6 +18,7 @@ package chiselverify.assertions
 import chisel3._
 import chiseltest._
 import chiseltest.internal.TesterThreadList
+import chiselverify.timing.TimedOp._
 import chiselverify.timing._
 
 /* Checks for a condition to be valid in the circuit at all times, or within the specified amount of clock cycles.
@@ -31,8 +32,63 @@ import chiselverify.timing._
   * @author Niels Frederik Flemming Holm Frandsen, s194053@student.dtu.dk
   */
 object AssertTimed {
-    def apply[T <: Module](dut: T, cond: () => Boolean = () => true, message: String = "Assertion Error")
-                          (delayType: DelayType = NoDelay): TesterThreadList = delayType match {
+    def apply[T <: Module](dut: T, op: TimedOperator, message: String)
+                          (delayType: DelayType): TesterThreadList = delayType match {
+        case NoDelay => fork {
+            assert(op.compute(op.operand1.peek().litValue(), op.operand2.peek().litValue()), message)
+        }
+
+        case Always(delay) =>
+            //Sample op1 at cycle 0
+            val value1 = op.operand1.peek().litValue()
+            assert(op.compute(value1, op.operand2.peek().litValue()), message)
+
+            //Check the same thing at every cycle
+            fork {
+                dut.clock.step()
+                (1 until delay) foreach (_ => {
+                    assert(op.compute(value1, op.operand2.peek().litValue()), message)
+                    dut.clock.step()
+                })
+            }
+
+        case Exactly(delay) =>
+            //Sample operand 1 at cycle 0
+            val value1 = op.operand1.peek().litValue()
+
+            //Check the same thing in exactly x cycles
+            fork {
+                dut.clock.step(delay)
+                assert(op.compute(value1, op.operand2.peek().litValue()), message)
+            }
+
+        case Eventually(delay) =>
+            //Sample operand 1 at cycle 0
+            val value1 = op.operand1.peek().litValue()
+            val initRes = op.compute(value1, op.operand2.peek().litValue())
+            fork {
+                assert((1 until delay).exists(_ => {
+                    dut.clock.step()
+                    op.compute(value1, op.operand2.peek().litValue())
+                }) || initRes, message)
+            }
+
+        case Never(delay) =>
+            //Sample op1 at cycle 0
+            val value1 = op.operand1.peek().litValue()
+            assert(!op.compute(value1, op.operand2.peek().litValue()), message)
+
+            //Check the same thing at every cycle
+            fork {
+                dut.clock.step()
+                (1 until delay) foreach (_ => {
+                    assert(!op.compute(value1, op.operand2.peek().litValue()), message)
+                    dut.clock.step()
+                })
+            }
+    }
+    def apply[T <: Module](dut: T, cond: () => Boolean, message: String)
+                          (delayType: DelayType): TesterThreadList = delayType match {
         //Basic assertion
         case NoDelay => fork {
             assert(cond(), message)

--- a/src/main/scala/chiselverify/coverage/package.scala
+++ b/src/main/scala/chiselverify/coverage/package.scala
@@ -18,7 +18,8 @@ package chiselverify
 import chisel3.Data
 import chiseltest.testableData
 import chiselverify.coverage.CoverReport._
-import chiselverify.timing._
+import chiselverify.timing.TimedOp._
+import chiselverify.timing.{DelayType, TimedOp}
 
 package object coverage {
     /**

--- a/src/main/scala/chiselverify/coverage/package.scala
+++ b/src/main/scala/chiselverify/coverage/package.scala
@@ -19,7 +19,7 @@ import chisel3.Data
 import chiseltest.testableData
 import chiselverify.coverage.CoverReport._
 import chiselverify.timing.TimedOp._
-import chiselverify.timing.{DelayType, TimedOp}
+import chiselverify.timing._
 
 package object coverage {
     /**

--- a/src/main/scala/chiselverify/timing/TimedOp.scala
+++ b/src/main/scala/chiselverify/timing/TimedOp.scala
@@ -1,0 +1,24 @@
+package chiselverify.timing
+
+import chisel3.Data
+
+/**
+  * Set of timing operators (only usable if a Timing delay is available)
+  */
+object TimedOp {
+
+    /**
+      * Represents a timed operation
+      * @param operands the operands needed for the operation
+      */
+    abstract class TimedOperator(val operand1: Data, val operand2: Data)
+
+    case object NoOp extends TimedOperator(null, null)
+
+    /**
+      * Checks if two operands are equal, given an certain timing delay
+      * @param op1 the first operand
+      * @param op2 the second operand
+      */
+    case class Equals(op1: Data, op2: Data) extends TimedOperator(op1, op2)
+}

--- a/src/main/scala/chiselverify/timing/TimedOp.scala
+++ b/src/main/scala/chiselverify/timing/TimedOp.scala
@@ -11,14 +11,26 @@ object TimedOp {
       * Represents a timed operation
       * @param operands the operands needed for the operation
       */
-    abstract class TimedOperator(val operand1: Data, val operand2: Data)
+    abstract class TimedOperator(val operand1: Data, val operand2: Data) {
+        /**
+          * Executes the current operation
+          * @param value1 the value of the first operand
+          * @param value2 the value of the second operand at the wanted cycle
+          * @return the result of the boolean operation
+          */
+        def compute(value1: BigInt, value2: BigInt): Boolean
+    }
 
-    case object NoOp extends TimedOperator(null, null)
+    case object NoOp extends TimedOperator(null, null) {
+        override def compute(value1: BigInt, value2: BigInt): Boolean = true
+    }
 
     /**
       * Checks if two operands are equal, given an certain timing delay
       * @param op1 the first operand
       * @param op2 the second operand
       */
-    case class Equals(op1: Data, op2: Data) extends TimedOperator(op1, op2)
+    case class Equals(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
+        override def compute(value1: BigInt, value2: BigInt): Boolean = value1 == value2
+    }
 }

--- a/src/main/scala/chiselverify/timing/TimedOp.scala
+++ b/src/main/scala/chiselverify/timing/TimedOp.scala
@@ -33,4 +33,40 @@ object TimedOp {
     case class Equals(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
         override def compute(value1: BigInt, value2: BigInt): Boolean = value1 == value2
     }
+
+    /**
+      * Greater than timed operator ( op1 > (op2 after x cycles) )
+      * @param op1 the first operand
+      * @param op2 the second operand
+      */
+    case class Gt(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
+        override def compute(value1: BigInt, value2: BigInt): Boolean = value1 > value2
+    }
+
+    /**
+      * Less than timed operator ( op1 < (op2 after x cycles) )
+      * @param op1 the first operand
+      * @param op2 the second operand
+      */
+    case class Lt(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
+        override def compute(value1: BigInt, value2: BigInt): Boolean = value1 < value2
+    }
+
+    /**
+      * Less than or Equal to timed operator ( op1 <= (op2 after x cycles) )
+      * @param op1 the first operand
+      * @param op2 the second operand
+      */
+    case class LtEq(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
+        override def compute(value1: BigInt, value2: BigInt): Boolean = value1 <= value2
+    }
+
+    /**
+      * Greater than or equal to timed operator ( op1 >= (op2 after x cycles) )
+      * @param op1 the first operand
+      * @param op2 the second operand
+      */
+    case class GtEq(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
+        override def compute(value1: BigInt, value2: BigInt): Boolean = value1 >= value2
+    }
 }

--- a/src/test/scala/verifyTests/ToyDUT.scala
+++ b/src/test/scala/verifyTests/ToyDUT.scala
@@ -48,11 +48,16 @@ object ToyDUT {
             val aEqb = Output(UInt(1.W))
             val aNevEqb = Output(UInt(1.W))
             val aEvEqC = Output(UInt(1.W))
+            val isOne = Output(UInt(1.W))
+            val outA = Output(UInt(size.W))
+            val outB = Output(UInt(size.W))
+            val outC = Output(UInt(size.W))
         })
 
         //Create a counter that should eventually reach a
         val c = Counter(size + 10)
         val aWire = RegInit(io.a)
+        val aHasEqb = RegInit(0.U)
 
         c.inc()
 
@@ -61,9 +66,18 @@ object ToyDUT {
             aWire := c.value
         }
 
+        io.aNevEqb := 1.U
+        when(aWire === io.b) {
+            aHasEqb := 1.U
+        }
+
         //Set outputs
         io.aEqb := (aWire === io.b).asUInt()
-        io.aNevEqb := (aWire =/= io.b).asUInt()
+        io.aNevEqb := (aHasEqb === 0.U).asUInt()
         io.aEvEqC := (aWire === c.value).asUInt()
+        io.isOne := 1.U
+        io.outA := io.a
+        io.outB := io.b
+        io.outC := c.value
     }
 }

--- a/src/test/scala/verifyTests/ToyDUT.scala
+++ b/src/test/scala/verifyTests/ToyDUT.scala
@@ -52,12 +52,15 @@ object ToyDUT {
             val outA = Output(UInt(size.W))
             val outB = Output(UInt(size.W))
             val outC = Output(UInt(size.W))
+            val outCSupB = Output(UInt((size + 1).W))
+            val outCNotSupB = Output(UInt(size.W))
         })
 
         //Create a counter that should eventually reach a
         val c = Counter(size + 10)
         val aWire = RegInit(io.a)
         val aHasEqb = RegInit(0.U)
+        val cSupb = RegInit(0.U)
 
         c.inc()
 
@@ -71,6 +74,10 @@ object ToyDUT {
             aHasEqb := 1.U
         }
 
+        when(c.value > io.b) {
+            cSupb := 1.U
+        }
+
         //Set outputs
         io.aEqb := (aWire === io.b).asUInt()
         io.aNevEqb := (aHasEqb === 0.U).asUInt()
@@ -79,5 +86,7 @@ object ToyDUT {
         io.outA := io.a
         io.outB := io.b
         io.outC := c.value
+        io.outCSupB := io.b + cSupb
+        io.outCNotSupB := io.b - cSupb
     }
 }

--- a/src/test/scala/verifyTests/assertions/TimedAssertionTests.scala
+++ b/src/test/scala/verifyTests/assertions/TimedAssertionTests.scala
@@ -4,7 +4,7 @@ import chisel3._
 import chisel3.tester._
 import chiseltest.ChiselScalatestTester
 import chiselverify.assertions.{AssertTimed, ExpectTimed}
-import chiselverify.timing.TimedOp.Equals
+import chiselverify.timing.TimedOp.{Equals, Gt}
 import chiselverify.timing._
 import org.scalatest.{FlatSpec, Matchers}
 import verifyTests.ToyDUT.AssertionsToyDUT
@@ -94,6 +94,50 @@ class TimedAssertionTests extends FlatSpec with ChiselScalatestTester with Match
         }
     }
 
+    def testGenericGtOp[T <: AssertionsToyDUT](dut: T, et : EventType): Unit = {
+
+        /**
+          * Basic test to see if we get the right amount of hits
+          */
+        def testAlways(): Unit = {
+            dut.io.a.poke(20.U)
+            dut.io.b.poke(10.U)
+            dut.clock.step(1)
+            println(s"aEqb is ${dut.io.aEqb.peek().litValue()}")
+            AssertTimed(dut, Gt(dut.io.outA, dut.io.outB), "a isn't always superior to one")(Always(9)).join()
+        }
+
+        def testEventually(): Unit = {
+            dut.io.a.poke(4.U)
+            dut.io.b.poke(2.U)
+            dut.clock.step()
+            AssertTimed(dut, Gt(dut.io.outB, dut.io.outCNotSupB), "c isn't eventually greater than b")(Eventually(4)).join()
+        }
+
+        def testExactly(): Unit = {
+            dut.io.a.poke(6.U)
+            dut.io.b.poke(5.U)
+            dut.clock.step(2)
+            println(s"C = ${dut.io.outC.peek().litValue()}")
+
+            AssertTimed(dut, Gt(dut.io.outB, dut.io.outCNotSupB), "c isn't greater than b after 7 cycles")(Exactly(7)).join()
+        }
+
+        def testNever(): Unit = {
+            dut.io.a.poke(10.U)
+            dut.io.b.poke(20.U)
+            dut.clock.step(1)
+            AssertTimed(dut, Gt(dut.io.outC, dut.io.outA), "a is equal to b at some point")(Never(10)).join()
+        }
+
+        et match {
+            case Always => testAlways()
+            case Eventually => testEventually()
+            case Exactly => testExactly()
+            case Never => testNever()
+        }
+    }
+
     "Timed Assertions Always" should "pass" in {
         test(new AssertionsToyDUT(32)){ dut => testGeneric(dut, Always) }
     }
@@ -106,6 +150,7 @@ class TimedAssertionTests extends FlatSpec with ChiselScalatestTester with Match
     "Timed Assertions Never" should "pass" in {
         test(new AssertionsToyDUT(32)){ dut => testGeneric(dut, Never) }
     }
+
     "Timed Assertions Always with Equals Op" should "pass" in {
         test(new AssertionsToyDUT(32)){dut => testGenericEqualsOp(dut, Always)}
     }
@@ -117,5 +162,18 @@ class TimedAssertionTests extends FlatSpec with ChiselScalatestTester with Match
     }
     "Timed Assertions Never with Equals Op" should "pass" in {
         test(new AssertionsToyDUT(32)){ dut => testGenericEqualsOp(dut, Never) }
+    }
+
+    "Timed Assertions Always with GreaterThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){dut => testGenericGtOp(dut, Always)}
+    }
+    "Timed Assertions Eventually with GreaterThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericGtOp(dut, Eventually) }
+    }
+    "Timed Assertions Exactly with GreaterThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericGtOp(dut, Exactly) }
+    }
+    "Timed Assertions Never with GreaterThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericGtOp(dut, Never) }
     }
 }

--- a/src/test/scala/verifyTests/assertions/TimedAssertionTests.scala
+++ b/src/test/scala/verifyTests/assertions/TimedAssertionTests.scala
@@ -4,7 +4,7 @@ import chisel3._
 import chisel3.tester._
 import chiseltest.ChiselScalatestTester
 import chiselverify.assertions.{AssertTimed, ExpectTimed}
-import chiselverify.timing.TimedOp.{Equals, Gt}
+import chiselverify.timing.TimedOp.{Equals, Gt, GtEq, Lt, LtEq}
 import chiselverify.timing._
 import org.scalatest.{FlatSpec, Matchers}
 import verifyTests.ToyDUT.AssertionsToyDUT
@@ -138,6 +138,138 @@ class TimedAssertionTests extends FlatSpec with ChiselScalatestTester with Match
         }
     }
 
+    def testGenericLtOp[T <: AssertionsToyDUT](dut: T, et : EventType): Unit = {
+
+        /**
+          * Basic test to see if we get the right amount of hits
+          */
+        def testAlways(): Unit = {
+            dut.io.a.poke(10.U)
+            dut.io.b.poke(20.U)
+            dut.clock.step(1)
+            println(s"aEqb is ${dut.io.aEqb.peek().litValue()}")
+            AssertTimed(dut, Lt(dut.io.outA, dut.io.outB), "a isn't always less than one")(Always(9)).join()
+        }
+
+        def testEventually(): Unit = {
+            dut.io.a.poke(4.U)
+            dut.io.b.poke(2.U)
+            dut.clock.step()
+            AssertTimed(dut, Lt(dut.io.outB, dut.io.outCSupB), "c isn't eventually less than b")(Eventually(4)).join()
+        }
+
+        def testExactly(): Unit = {
+            dut.io.a.poke(6.U)
+            dut.io.b.poke(5.U)
+            dut.clock.step(2)
+            println(s"C = ${dut.io.outC.peek().litValue()}")
+
+            AssertTimed(dut, Lt(dut.io.outB, dut.io.outCSupB), "c isn't less than b after 7 cycles")(Exactly(7)).join()
+        }
+
+        def testNever(): Unit = {
+            dut.io.a.poke(10.U)
+            dut.io.b.poke(20.U)
+            dut.clock.step(1)
+            AssertTimed(dut, Lt(dut.io.outB, dut.io.outCNotSupB), "a is never less than c at any point")(Never(10)).join()
+        }
+
+        et match {
+            case Always => testAlways()
+            case Eventually => testEventually()
+            case Exactly => testExactly()
+            case Never => testNever()
+        }
+    }
+
+    def testGenericLtEqOp[T <: AssertionsToyDUT](dut: T, et : EventType): Unit = {
+
+        /**
+          * Basic test to see if we get the right amount of hits
+          */
+        def testAlways(): Unit = {
+            dut.io.a.poke(10.U)
+            dut.io.b.poke(20.U)
+            dut.clock.step(1)
+            println(s"aEqb is ${dut.io.aEqb.peek().litValue()}")
+            AssertTimed(dut, LtEq(dut.io.outA, dut.io.outB), "a isn't always less than one")(Always(9)).join()
+        }
+
+        def testEventually(): Unit = {
+            dut.io.a.poke(4.U)
+            dut.io.b.poke(2.U)
+            dut.clock.step()
+            AssertTimed(dut, LtEq(dut.io.outB, dut.io.outCSupB), "c isn't eventually less than b")(Eventually(4)).join()
+        }
+
+        def testExactly(): Unit = {
+            dut.io.a.poke(6.U)
+            dut.io.b.poke(5.U)
+            dut.clock.step(2)
+            println(s"C = ${dut.io.outC.peek().litValue()}")
+
+            AssertTimed(dut, LtEq(dut.io.outB, dut.io.outCSupB), "c isn't less than b after 7 cycles")(Exactly(7)).join()
+        }
+
+        def testNever(): Unit = {
+            dut.io.a.poke(10.U)
+            dut.io.b.poke(11.U)
+            dut.clock.step(1)
+            AssertTimed(dut, LtEq(dut.io.outB, dut.io.outC), "a is never less than c at any point")(Never(10)).join()
+        }
+
+        et match {
+            case Always => testAlways()
+            case Eventually => testEventually()
+            case Exactly => testExactly()
+            case Never => testNever()
+        }
+    }
+
+    def testGenericGtEqOp[T <: AssertionsToyDUT](dut: T, et : EventType): Unit = {
+
+        /**
+          * Basic test to see if we get the right amount of hits
+          */
+        def testAlways(): Unit = {
+            dut.io.a.poke(10.U)
+            dut.io.b.poke(20.U)
+            dut.clock.step(1)
+            println(s"aEqb is ${dut.io.aEqb.peek().litValue()}")
+            AssertTimed(dut, GtEq(dut.io.outB, dut.io.outA), "a isn't always less than one")(Always(9)).join()
+        }
+
+        def testEventually(): Unit = {
+            dut.io.a.poke(4.U)
+            dut.io.b.poke(2.U)
+            dut.clock.step()
+            AssertTimed(dut, GtEq(dut.io.outB, dut.io.outCNotSupB), "c isn't eventually less than b")(Eventually(4)).join()
+        }
+
+        def testExactly(): Unit = {
+            dut.io.a.poke(6.U)
+            dut.io.b.poke(5.U)
+            dut.clock.step(2)
+            println(s"C = ${dut.io.outC.peek().litValue()}")
+
+            AssertTimed(dut, GtEq(dut.io.outB, dut.io.outCNotSupB), "c isn't less than b after 7 cycles")(Exactly(7)).join()
+        }
+
+        def testNever(): Unit = {
+            dut.io.a.poke(10.U)
+            dut.io.b.poke(0.U)
+            dut.clock.step(1)
+            AssertTimed(dut, GtEq(dut.io.outB, dut.io.outC), "a is never less than c at any point")(Never(10)).join()
+        }
+
+        et match {
+            case Always => testAlways()
+            case Eventually => testEventually()
+            case Exactly => testExactly()
+            case Never => testNever()
+        }
+    }
+
     "Timed Assertions Always" should "pass" in {
         test(new AssertionsToyDUT(32)){ dut => testGeneric(dut, Always) }
     }
@@ -175,5 +307,44 @@ class TimedAssertionTests extends FlatSpec with ChiselScalatestTester with Match
     }
     "Timed Assertions Never with GreaterThan Op" should "pass" in {
         test(new AssertionsToyDUT(32)){ dut => testGenericGtOp(dut, Never) }
+    }
+
+    "Timed Assertions Always with LessThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){dut => testGenericLtOp(dut, Always)}
+    }
+    "Timed Assertions Eventually with LessThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericLtOp(dut, Eventually) }
+    }
+    "Timed Assertions Exactly with LessThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericLtOp(dut, Exactly) }
+    }
+    "Timed Assertions Never with LessThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericLtOp(dut, Never) }
+    }
+
+    "Timed Assertions Always with LessThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){dut => testGenericLtEqOp(dut, Always)}
+    }
+    "Timed Assertions Eventually with LessThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericLtEqOp(dut, Eventually) }
+    }
+    "Timed Assertions Exactly with LessThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericLtEqOp(dut, Exactly) }
+    }
+    "Timed Assertions Never with LessThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericLtEqOp(dut, Never) }
+    }
+
+    "Timed Assertions Always with GreaterThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){dut => testGenericGtEqOp(dut, Always)}
+    }
+    "Timed Assertions Eventually with GreaterThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericGtEqOp(dut, Eventually) }
+    }
+    "Timed Assertions Exactly with GreaterThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericGtEqOp(dut, Exactly) }
+    }
+    "Timed Assertions Never with GreaterThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericGtEqOp(dut, Never) }
     }
 }


### PR DESCRIPTION
This PR extends the timed assertions to allow for comparisons between two ports with values sampled at different cycles.  
Currently, Timed Assertions only allow to test a given predicate with a certain timing delay, but this doesn't not make it possible to test for example if a first port is equal to a second port sampled 7 cycles later.   

This PR thus adds a set of `TimedOperations` that allow to check assertions by comparing two ports at different cycles using the currently existing timing delays.  These new constructs have the following signature:  
```scala
abstract class TimedOperations(operand1: Data, operand2: Data) {  
    def compute(val1: BigInt, val2: BigInt): Boolean) // The comparison function between both sampled values
}
```
The list of tested operations are the following:  
- `Equals`: Checks if the first operand sampled at cycle 0 is __equal to__ a second operand sampled after a delay.  
- `Gt`: Checks if the first operand sampled at cycle 0 is __greater than__ a second operand sampled after a delay.  
- `Lt`: Checks if the first operand sampled at cycle 0 is __less than__ a second operand sampled after a delay.  
- `GtEq`: Checks if the first operand sampled at cycle 0 is __greater than or equal to__ a second operand sampled after a delay.  
- `LtEq`: Checks if the first operand sampled at cycle 0 is __less than or equal to__ a second operand sampled after a delay.   
  
### Example use case  
Here is a toy example of how to use the assertion:  
```scala
AssertTimed(dut, LtEq(dut.io.outB, dut.io.outA), "a isn't always less than or equal to one")(Always(9)).join()
AssertTimed(dut, GtEq(dut.io.outB, dut.io.outA), "a isn't always greater than or equal to one")(Always(9)).join()
``` 