### PR TITLE
Added Timed Operations for Coverage 

### DIFF
--- a/src/main/scala/chiselverify/assertions/AssertTimed.scala
+++ b/src/main/scala/chiselverify/assertions/AssertTimed.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2020 DTU Compute - Section for Embedded Systems Engineering
+* Copyright 2021 DTU Compute - Section for Embedded Systems Engineering
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/main/scala/chiselverify/assertions/AssertTimed.scala
+++ b/src/main/scala/chiselverify/assertions/AssertTimed.scala
@@ -18,6 +18,7 @@ package chiselverify.assertions
 import chisel3._
 import chiseltest._
 import chiseltest.internal.TesterThreadList
+import chiselverify.timing.TimedOp._
 import chiselverify.timing._
 
 /* Checks for a condition to be valid in the circuit at all times, or within the specified amount of clock cycles.
@@ -31,8 +32,63 @@ import chiselverify.timing._
   * @author Niels Frederik Flemming Holm Frandsen, s194053@student.dtu.dk
   */
 object AssertTimed {
-    def apply[T <: Module](dut: T, cond: () => Boolean = () => true, message: String = "Assertion Error")
-                          (delayType: DelayType = NoDelay): TesterThreadList = delayType match {
+    def apply[T <: Module](dut: T, op: TimedOperator, message: String)
+                          (delayType: DelayType): TesterThreadList = delayType match {
+        case NoDelay => fork {
+            assert(op.compute(op.operand1.peek().litValue(), op.operand2.peek().litValue()), message)
+        }
+
+        case Always(delay) =>
+            //Sample op1 at cycle 0
+            val value1 = op.operand1.peek().litValue()
+            assert(op.compute(value1, op.operand2.peek().litValue()), message)
+
+            //Check the same thing at every cycle
+            fork {
+                dut.clock.step()
+                (1 until delay) foreach (_ => {
+                    assert(op.compute(value1, op.operand2.peek().litValue()), message)
+                    dut.clock.step()
+                })
+            }
+
+        case Exactly(delay) =>
+            //Sample operand 1 at cycle 0
+            val value1 = op.operand1.peek().litValue()
+
+            //Check the same thing in exactly x cycles
+            fork {
+                dut.clock.step(delay)
+                assert(op.compute(value1, op.operand2.peek().litValue()), message)
+            }
+
+        case Eventually(delay) =>
+            //Sample operand 1 at cycle 0
+            val value1 = op.operand1.peek().litValue()
+            val initRes = op.compute(value1, op.operand2.peek().litValue())
+            fork {
+                assert((1 until delay).exists(_ => {
+                    dut.clock.step()
+                    op.compute(value1, op.operand2.peek().litValue())
+                }) || initRes, message)
+            }
+
+        case Never(delay) =>
+            //Sample op1 at cycle 0
+            val value1 = op.operand1.peek().litValue()
+            assert(!op.compute(value1, op.operand2.peek().litValue()), message)
+
+            //Check the same thing at every cycle
+            fork {
+                dut.clock.step()
+                (1 until delay) foreach (_ => {
+                    assert(!op.compute(value1, op.operand2.peek().litValue()), message)
+                    dut.clock.step()
+                })
+            }
+    }
+    def apply[T <: Module](dut: T, cond: () => Boolean, message: String)
+                          (delayType: DelayType): TesterThreadList = delayType match {
         //Basic assertion
         case NoDelay => fork {
             assert(cond(), message)

--- a/src/main/scala/chiselverify/assertions/ExpectTimed.scala
+++ b/src/main/scala/chiselverify/assertions/ExpectTimed.scala
@@ -1,3 +1,18 @@
+/*
+* Copyright 2020 DTU Compute - Section for Embedded Systems Engineering
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+* or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
 package chiselverify.assertions
 
 import chisel3._

--- a/src/main/scala/chiselverify/coverage/CoverReport.scala
+++ b/src/main/scala/chiselverify/coverage/CoverReport.scala
@@ -91,7 +91,7 @@ object CoverReport {
           * @param binName   the name of the bin itself
           * @return
           */
-        def binNHits(groupId: BigInt, pointName: String, bN: Option[String]): BigInt = {
+        def binNHits(groupId: BigInt, pointName: String, bN: Option[String] = None): BigInt = {
             val binName =  bN.getOrElse("NoName")
             //Look for the group
             groups.find(_.id == groupId) match {
@@ -248,9 +248,14 @@ object CoverReport {
         override def report: String = s"${timedCoverOp.serialize} HAS $nHits HIT(S)."
 
         /**
+          * String ID for the current report
+          */
+        override val name: String = timedCoverOp.pointName
+
+        /**
           * Integer ID for the current report
           */
-        override val id: BigInt = name.hashCode
+        override val id: BigInt = timedCoverOp.pointName.hashCode
 
         /**
           * Adds two different reports of the same type together
@@ -261,11 +266,6 @@ object CoverReport {
         override def +(that: Report): Report = that match {
             case TimedOpReport(t, hits) => TimedOpReport(timedCoverOp + t, nHits + hits)
         }
-
-        /**
-          * String ID for the current report
-          */
-        override val name: String = timedCoverOp.pointName
     }
 
     /**

--- a/src/main/scala/chiselverify/coverage/CoverReport.scala
+++ b/src/main/scala/chiselverify/coverage/CoverReport.scala
@@ -261,6 +261,11 @@ object CoverReport {
         override def +(that: Report): Report = that match {
             case TimedOpReport(t, hits) => TimedOpReport(timedCoverOp + t, nHits + hits)
         }
+
+        /**
+          * String ID for the current report
+          */
+        override val name: String = timedCoverOp.pointName
     }
 
     /**

--- a/src/main/scala/chiselverify/coverage/CoverReport.scala
+++ b/src/main/scala/chiselverify/coverage/CoverReport.scala
@@ -1,3 +1,18 @@
+/*
+* Copyright 2021 DTU Compute - Section for Embedded Systems Engineering
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+* or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
 package chiselverify.coverage
 
 import chiselverify.timing.{DelayType, NoDelay}
@@ -76,7 +91,8 @@ object CoverReport {
           * @param binName   the name of the bin itself
           * @return
           */
-        def binNHits(groupId: BigInt, pointName: String, binName: String): BigInt = {
+        def binNHits(groupId: BigInt, pointName: String, bN: Option[String]): BigInt = {
+            val binName =  bN.getOrElse("NoName")
             //Look for the group
             groups.find(_.id == groupId) match {
                 case None => throw new IllegalArgumentException(s"No group with ID $groupId!!")
@@ -103,6 +119,7 @@ object CoverReport {
                                             case _ => throw new IllegalStateException("Bin must be reported with a BinReport")
                                         }
                                     }
+                                case TimedOpReport(_, nHits) => nHits
                                 case ConditionReport(_, conds, db) =>
                                     conds.find(_.name == binName) match {
                                         case None => throw new IllegalArgumentException(s"No condition with name $binName!!")
@@ -220,6 +237,30 @@ object CoverReport {
         }
 
         override val id: BigInt = name.hashCode
+    }
+
+    case class TimedOpReport(timedCoverOp: TimedCoverOp, nHits: Int) extends Report {
+        /**
+          * Generates a part of or the entirety of the coverage report
+          *
+          * @return a string containing the coverage report
+          */
+        override def report: String = s"${timedCoverOp.serialize} HAS $nHits HIT(S)."
+
+        /**
+          * Integer ID for the current report
+          */
+        override val id: BigInt = name.hashCode
+
+        /**
+          * Adds two different reports of the same type together
+          *
+          * @param that an other report of the same type as this one
+          * @return a concatenated version of the two reports
+          */
+        override def +(that: Report): Report = that match {
+            case TimedOpReport(t, hits) => TimedOpReport(timedCoverOp + t, nHits + hits)
+        }
     }
 
     /**

--- a/src/main/scala/chiselverify/coverage/CoverageReporter.scala
+++ b/src/main/scala/chiselverify/coverage/CoverageReporter.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2020 DTU Compute - Section for Embedded Systems Engineering
+* Copyright 2021 DTU Compute - Section for Embedded Systems Engineering
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/main/scala/chiselverify/coverage/Utils.scala
+++ b/src/main/scala/chiselverify/coverage/Utils.scala
@@ -83,4 +83,11 @@ object Utils {
         } yield List(x1, x2, x3, x4)
         case _ => throw new IllegalArgumentException("MAX ARRAY SIZE IN CARTESIAN PRODUCT IS 4")
     }
+
+    /**
+      * Implicit type conversion from string to option to simplify syntax
+      * @param s the string that will be converted
+      * @return an option containing the given string
+      */
+    implicit def stringToOption(s: String): Option[String] = Some(s)
 }

--- a/src/main/scala/chiselverify/coverage/package.scala
+++ b/src/main/scala/chiselverify/coverage/package.scala
@@ -223,16 +223,14 @@ package object coverage {
                     case Eventually(delay) => op1Vals.map(p =>
                         (p, op2Vals.filter(p2 => ((p.cycle + delay) >= p2.cycle) && (p.cycle <= p2.cycle))))
                         .filter { case (_, ts) => ts.size > delay }
-                        .map { case (t, ts) => if(ts.exists(t2 => op(t.value, t2.value))) 1 else 0 }
-                        .sum
+                        .count { case (t, ts) => ts.exists(t2 => op(t.value, t2.value)) }
 
                     //(op1, List of op2Vals where cycle is up to delay cycles later) then checked to find out if all
                     //entries than satisfies the operation
                     case Always(delay) => op1Vals.map(p =>
                         (p, op2Vals.filter(p2 => ((p.cycle + delay) >= p2.cycle) && (p.cycle <= p2.cycle))))
                         .filter { case (_, ts) => ts.size > delay }
-                        .map { case (t, ts) => if(ts.forall(t2 => op(t.value, t2.value))) 1 else 0 }
-                        .sum
+                        .count { case (t, ts) => ts.forall(t2 => op(t.value, t2.value)) }
 
                     case _ => throw new IllegalArgumentException(s"$delay DelayType not supported")
                 }

--- a/src/main/scala/chiselverify/coverage/package.scala
+++ b/src/main/scala/chiselverify/coverage/package.scala
@@ -228,7 +228,7 @@ package object coverage {
 
                     //(op1, List of op2Vals where cycle is up to delay cycles later) then checked to find out if all
                     //entries than satisfies the operation
-                    case Always(delay) => val a = op1Vals.map(p =>
+                    case Always(delay) => op1Vals.map(p =>
                         (p, op2Vals.filter(p2 => ((p.cycle + delay) >= p2.cycle) && (p.cycle <= p2.cycle))))
                         .filter { case (_, ts) => ts.size > delay }
                         .map { case (t, ts) => if(ts.forall(t2 => op(t.value, t2.value))) 1 else 0 }

--- a/src/main/scala/chiselverify/coverage/package.scala
+++ b/src/main/scala/chiselverify/coverage/package.scala
@@ -18,7 +18,8 @@ package chiselverify
 import chisel3.Data
 import chiseltest.testableData
 import chiselverify.coverage.CoverReport._
-import chiselverify.timing._
+import chiselverify.timing.TimedOp._
+import chiselverify.timing.{DelayType, TimedOp}
 
 package object coverage {
     /**

--- a/src/main/scala/chiselverify/coverage/package.scala
+++ b/src/main/scala/chiselverify/coverage/package.scala
@@ -19,7 +19,7 @@ import chisel3.Data
 import chiseltest.testableData
 import chiselverify.coverage.CoverReport._
 import chiselverify.timing.TimedOp._
-import chiselverify.timing.{DelayType, TimedOp}
+import chiselverify.timing._
 
 package object coverage {
     /**

--- a/src/main/scala/chiselverify/coverage/package.scala
+++ b/src/main/scala/chiselverify/coverage/package.scala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2020 DTU Compute - Section for Embedded Systems Engineering
+* Copyright 2021 DTU Compute - Section for Embedded Systems Engineering
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -174,7 +174,7 @@ package object coverage {
       */
     case class CoverPoint(pN: String, port: Data)(b: Bins*)
         extends Cover(pN, port::Nil) {
-        val bins: List[Bins] = if(b.isEmpty) List(DefaultBin(port)) else b.toList
+        val bins: List[Bins] = if (b.isEmpty) List(DefaultBin(port)) else b.toList
 
         override def serialize: String = s"CoverPoint($port, $pointName)(${bins.map(_.serialize)})"
 
@@ -191,53 +191,63 @@ package object coverage {
     }
 
     /**
-      * Represents a coverage relation between two different DUT ports
-      *
-      * @param name       the name that will be used to represent the relation in the report
-      * @param pointName1 the first point of the relation
-      * @param pointName2 the other point in the relation
-      * @param bins       the list of value ranges that will be checked for for the given relation
+      * Representation of a sampled timing value. This is used for the TimedCoverOp construct.
+      * @param operandNum either 1 or 2, represents which operand we are working with
+      * @param value, the sampled value of the port
+      * @param cycle, the cycle at which the value was sampled
       */
-    case class CrossPoint(n: String, p: Data*)(b: CrossBin*) extends Cross(n, p)(b.toList) {
+    case class TimingValue(operandNum: Int, value: BigInt, cycle: BigInt) {
+        if(operandNum > 2 || operandNum < 0)
+            throw new IllegalArgumentException(s"operand number can only be 1 or 2!!")
+    }
 
-        //Check that the correct number of ranges was given
-        override val bins: List[CrossBin] =
-            if(b.forall(_.ranges.length == ports.length)) b.toList
-            else throw new IllegalArgumentException(
-                "CrossBins must contain the same number of ranges as the number of ports in the CrossPoint!"
-            )
+    case class TimedCoverOp(pN: String, op: TimedOperator)(val delay: DelayType)
+        extends Cover(pN, Seq(op.operand1, op.operand2)) {
 
-        override def sample(db: CoverageDB): Unit = {
+        //Implicit reference to simplify internal DB function calls
+        implicit val _this: TimedCoverOp = this
 
-            //Sample all of the ports
-            val portVal = ports.map(_.peek().litValue())
+        override def report(db: CoverageDB): Report = {
+            def compileHits: Int = {
+                val timingVals = db.getTimingVals
+                val op1Vals = timingVals.filter(_.operandNum == 1).sortBy(_.cycle)
+                val op2Vals = timingVals.filter(_.operandNum == 2).sortBy(_.cycle)
 
-            //Check for hits with each bin
-            bins.foreach { b => if(portVal.zip(b.ranges).forall{ case (v, r) => r contains v })
-                    db.addCrossBinHit(b, portVal)
+                delay match {
+                    case Exactly(delay) => op1Vals.map(p => (p, op2Vals.filter((p.cycle + delay) == _.cycle)))
+                        .map { case (t, ts) => ts.map(t2 => op.compute(t.value, t2.value)).count(_ == true) }.sum
+
+                    case Eventually(delay) => op1Vals.map(p =>
+                        (p, op2Vals.filter(p2 => ((p.cycle + delay) > p2.cycle) && (p.cycle < p2.cycle))))
+                        .map { case (t, ts) => ts.map(t2 => op.compute(t.value, t2.value)).count(_ == true) }.sum
+
+                    case Always(delay) => op1Vals.map(p =>
+                        (p, op2Vals.filter(p2 => ((p.cycle + delay) > p2.cycle) && (p.cycle < p2.cycle))))
+                        .map { case (t, ts) => if(ts.forall(t2 => op.compute(t.value, t2.value))) 1 else 0 }.sum
+
+                    case _ => throw new IllegalArgumentException(s"$delay DelayType not supported")
+                }
             }
+
+            TimedOpReport(this, compileHits)
         }
 
-        override def register(db: CoverageDB): Unit = db.registerCross(this)
 
-        /**
-          * Generates a report in a form that is compatible with the coverage reporter
-          *
-          * @return a Report
-          */
-        override def report(db: CoverageDB): Report =
-            CrossReport(this, bins.map(cb => CrossBinReport(cb, db.getNHits(cb))))
+        override def serialize: String = s"TIMED_COVER_OP $pointName WITH DELAY ${delay.toString}"
 
-        /**
-          * Converts the current cover construct into a human-readable string
-          *
-          * @return a String representing the cover construct
-          */
-        override def serialize: String = s"CROSS $name"
+        override def sample(db: CoverageDB): Unit = {
+            val curCycle = db.getCurCycle
+
+            //Sample the two operands
+            db.addTimingValue(TimingValue(1, op.operand1.peek().litValue(), curCycle))
+            db.addTimingValue(TimingValue(2, op.operand2.peek().litValue(), curCycle))
+        }
+
+        override def register(db: CoverageDB): Unit = db.registerTimedCoverOp
     }
 
     /**
-      * A timed version of a cross point. This means that, given a delay, point 2 will be sampled a certain amount of 
+      * A timed version of a cross point. This means that, given a delay, point 2 will be sampled a certain amount of
       * cycles after point 1.
       *
       * @param n        the name of the cross, used for the report
@@ -324,7 +334,7 @@ package object coverage {
                                 BigInt(1)
                             else
                                 BigInt(0))
-                        case _ => (cb, BigInt(0))
+                        case _ => (cb, BigInt(0)) //Never isn't supported for coverage
                     }
                 })
             //Sanity check
@@ -338,6 +348,53 @@ package object coverage {
           * @return a String representing the cover construct
           */
         override def serialize: String = s"TIMED CROSS $name WITH DELAY $delay"
+    }
+
+
+    /**
+      * Represents a coverage relation between two different DUT ports
+      *
+      * @param name       the name that will be used to represent the relation in the report
+      * @param pointName1 the first point of the relation
+      * @param pointName2 the other point in the relation
+      * @param bins       the list of value ranges that will be checked for for the given relation
+      */
+    case class CrossPoint(n: String, p: Data*)(b: CrossBin*) extends Cross(n, p)(b.toList) {
+
+        //Check that the correct number of ranges was given
+        override val bins: List[CrossBin] =
+            if(b.forall(_.ranges.length == ports.length)) b.toList
+            else throw new IllegalArgumentException(
+                "CrossBins must contain the same number of ranges as the number of ports in the CrossPoint!"
+            )
+
+        override def sample(db: CoverageDB): Unit = {
+
+            //Sample all of the ports
+            val portVal = ports.map(_.peek().litValue())
+
+            //Check for hits with each bin
+            bins.foreach { b => if(portVal.zip(b.ranges).forall{ case (v, r) => r contains v })
+                    db.addCrossBinHit(b, portVal)
+            }
+        }
+
+        override def register(db: CoverageDB): Unit = db.registerCross(this)
+
+        /**
+          * Generates a report in a form that is compatible with the coverage reporter
+          *
+          * @return a Report
+          */
+        override def report(db: CoverageDB): Report =
+            CrossReport(this, bins.map(cb => CrossBinReport(cb, db.getNHits(cb))))
+
+        /**
+          * Converts the current cover construct into a human-readable string
+          *
+          * @return a String representing the cover construct
+          */
+        override def serialize: String = s"CROSS $name"
     }
 
     /**

--- a/src/main/scala/chiselverify/timing/TimedOp.scala
+++ b/src/main/scala/chiselverify/timing/TimedOp.scala
@@ -1,0 +1,24 @@
+package chiselverify.timing
+
+import chisel3.Data
+
+/**
+  * Set of timing operators (only usable if a Timing delay is available)
+  */
+object TimedOp {
+
+    /**
+      * Represents a timed operation
+      * @param operands the operands needed for the operation
+      */
+    abstract class TimedOperator(val operand1: Data, val operand2: Data)
+
+    case object NoOp extends TimedOperator(null, null)
+
+    /**
+      * Checks if two operands are equal, given an certain timing delay
+      * @param op1 the first operand
+      * @param op2 the second operand
+      */
+    case class Equals(op1: Data, op2: Data) extends TimedOperator(op1, op2)
+}

--- a/src/main/scala/chiselverify/timing/TimedOp.scala
+++ b/src/main/scala/chiselverify/timing/TimedOp.scala
@@ -11,14 +11,26 @@ object TimedOp {
       * Represents a timed operation
       * @param operands the operands needed for the operation
       */
-    abstract class TimedOperator(val operand1: Data, val operand2: Data)
+    abstract class TimedOperator(val operand1: Data, val operand2: Data) {
+        /**
+          * Executes the current operation
+          * @param value1 the value of the first operand
+          * @param value2 the value of the second operand at the wanted cycle
+          * @return the result of the boolean operation
+          */
+        def compute(value1: BigInt, value2: BigInt): Boolean
+    }
 
-    case object NoOp extends TimedOperator(null, null)
+    case object NoOp extends TimedOperator(null, null) {
+        override def compute(value1: BigInt, value2: BigInt): Boolean = true
+    }
 
     /**
       * Checks if two operands are equal, given an certain timing delay
       * @param op1 the first operand
       * @param op2 the second operand
       */
-    case class Equals(op1: Data, op2: Data) extends TimedOperator(op1, op2)
+    case class Equals(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
+        override def compute(value1: BigInt, value2: BigInt): Boolean = value1 == value2
+    }
 }

--- a/src/main/scala/chiselverify/timing/TimedOp.scala
+++ b/src/main/scala/chiselverify/timing/TimedOp.scala
@@ -33,4 +33,40 @@ object TimedOp {
     case class Equals(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
         override def compute(value1: BigInt, value2: BigInt): Boolean = value1 == value2
     }
+
+    /**
+      * Greater than timed operator ( op1 > (op2 after x cycles) )
+      * @param op1 the first operand
+      * @param op2 the second operand
+      */
+    case class Gt(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
+        override def compute(value1: BigInt, value2: BigInt): Boolean = value1 > value2
+    }
+
+    /**
+      * Less than timed operator ( op1 < (op2 after x cycles) )
+      * @param op1 the first operand
+      * @param op2 the second operand
+      */
+    case class Lt(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
+        override def compute(value1: BigInt, value2: BigInt): Boolean = value1 < value2
+    }
+
+    /**
+      * Less than or Equal to timed operator ( op1 <= (op2 after x cycles) )
+      * @param op1 the first operand
+      * @param op2 the second operand
+      */
+    case class LtEq(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
+        override def compute(value1: BigInt, value2: BigInt): Boolean = value1 <= value2
+    }
+
+    /**
+      * Greater than or equal to timed operator ( op1 >= (op2 after x cycles) )
+      * @param op1 the first operand
+      * @param op2 the second operand
+      */
+    case class GtEq(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
+        override def compute(value1: BigInt, value2: BigInt): Boolean = value1 >= value2
+    }
 }

--- a/src/main/scala/chiselverify/timing/TimedOp.scala
+++ b/src/main/scala/chiselverify/timing/TimedOp.scala
@@ -36,23 +36,25 @@ object TimedOp {
           * @param value2 the value of the second operand at the wanted cycle
           * @return the result of the boolean operation
           */
-        def compute(value1: BigInt, value2: BigInt): Boolean
+        def apply(value1: BigInt, value2: BigInt): Boolean
 
         /**
           * Defines a new TimedOperator as the sum of two existing ones
           * @param that the Timed operator that we want to sum to ours
           * @return an operator that considers a result true if it satisfies both operators
           */
-        def +(that: TimedOperator): TimedOperator =
+        def +(that: TimedOperator): TimedOperator = {
+            val compute1 = this(operand1.peek().litValue(), operand2.peek().litValue())
+            val compute2 = that(that.operand1.peek().litValue(), that.operand2.peek().litValue())
+
             new TimedOperator(operand1, operand2, that.operand1, that.operand2) {
-                override def compute(value1: BigInt, value2: BigInt): Boolean =
-                    compute(operand1.peek().litValue(), operand2.peek().litValue()) &&
-                        compute(that.operand1.peek().litValue(), that.operand2.peek().litValue())
+                override def apply(value1: BigInt, value2: BigInt): Boolean = compute1 && compute2
             }
+        }
     }
 
     case object NoOp extends TimedOperator(null, null) {
-        override def compute(value1: BigInt, value2: BigInt): Boolean = true
+        override def apply(value1: BigInt, value2: BigInt): Boolean = true
     }
 
     /**
@@ -61,7 +63,7 @@ object TimedOp {
       * @param op2 the second operand
       */
     case class Equals(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
-        override def compute(value1: BigInt, value2: BigInt): Boolean = value1 == value2
+        override def apply(value1: BigInt, value2: BigInt): Boolean = value1 == value2
     }
 
     /**
@@ -70,7 +72,7 @@ object TimedOp {
       * @param op2 the second operand
       */
     case class Gt(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
-        override def compute(value1: BigInt, value2: BigInt): Boolean = value1 > value2
+        override def apply(value1: BigInt, value2: BigInt): Boolean = value1 > value2
     }
 
     /**
@@ -79,7 +81,7 @@ object TimedOp {
       * @param op2 the second operand
       */
     case class Lt(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
-        override def compute(value1: BigInt, value2: BigInt): Boolean = value1 < value2
+        override def apply(value1: BigInt, value2: BigInt): Boolean = value1 < value2
     }
 
     /**
@@ -88,7 +90,7 @@ object TimedOp {
       * @param op2 the second operand
       */
     case class LtEq(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
-        override def compute(value1: BigInt, value2: BigInt): Boolean = value1 <= value2
+        override def apply(value1: BigInt, value2: BigInt): Boolean = value1 <= value2
     }
 
     /**
@@ -97,6 +99,6 @@ object TimedOp {
       * @param op2 the second operand
       */
     case class GtEq(op1: Data, op2: Data) extends TimedOperator(op1, op2) {
-        override def compute(value1: BigInt, value2: BigInt): Boolean = value1 >= value2
+        override def apply(value1: BigInt, value2: BigInt): Boolean = value1 >= value2
     }
 }

--- a/src/main/scala/chiselverify/timing/package.scala
+++ b/src/main/scala/chiselverify/timing/package.scala
@@ -1,3 +1,18 @@
+/*
+* Copyright 2021 DTU Compute - Section for Embedded Systems Engineering
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+* or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
 package chiselverify
 
 package object timing {

--- a/src/test/scala/verifyTests/ToyDUT.scala
+++ b/src/test/scala/verifyTests/ToyDUT.scala
@@ -48,11 +48,16 @@ object ToyDUT {
             val aEqb = Output(UInt(1.W))
             val aNevEqb = Output(UInt(1.W))
             val aEvEqC = Output(UInt(1.W))
+            val isOne = Output(UInt(1.W))
+            val outA = Output(UInt(size.W))
+            val outB = Output(UInt(size.W))
+            val outC = Output(UInt(size.W))
         })
 
         //Create a counter that should eventually reach a
         val c = Counter(size + 10)
         val aWire = RegInit(io.a)
+        val aHasEqb = RegInit(0.U)
 
         c.inc()
 
@@ -61,9 +66,18 @@ object ToyDUT {
             aWire := c.value
         }
 
+        io.aNevEqb := 1.U
+        when(aWire === io.b) {
+            aHasEqb := 1.U
+        }
+
         //Set outputs
         io.aEqb := (aWire === io.b).asUInt()
-        io.aNevEqb := (aWire =/= io.b).asUInt()
+        io.aNevEqb := (aHasEqb === 0.U).asUInt()
         io.aEvEqC := (aWire === c.value).asUInt()
+        io.isOne := 1.U
+        io.outA := io.a
+        io.outB := io.b
+        io.outC := c.value
     }
 }

--- a/src/test/scala/verifyTests/ToyDUT.scala
+++ b/src/test/scala/verifyTests/ToyDUT.scala
@@ -16,15 +16,16 @@ object ToyDUT {
             val count = Output(UInt(size.W))
             val outB = Output(UInt(size.W))
             val outC = Output(UInt(size.W))
+            val outSum = Output(UInt((size + 1).W))
         })
-        val regA = Counter(5)
-
+        val regA: Counter = Counter(size + 10)
         regA.inc()
 
         io.outA := io.a
         io.count := regA.value
         io.outB := io.b
         io.outC := io.c
+        io.outSum := io.a + regA.value
     }
 
     class BasicToyDUT(size: Int) extends Module {

--- a/src/test/scala/verifyTests/ToyDUT.scala
+++ b/src/test/scala/verifyTests/ToyDUT.scala
@@ -52,12 +52,15 @@ object ToyDUT {
             val outA = Output(UInt(size.W))
             val outB = Output(UInt(size.W))
             val outC = Output(UInt(size.W))
+            val outCSupB = Output(UInt((size + 1).W))
+            val outCNotSupB = Output(UInt(size.W))
         })
 
         //Create a counter that should eventually reach a
         val c = Counter(size + 10)
         val aWire = RegInit(io.a)
         val aHasEqb = RegInit(0.U)
+        val cSupb = RegInit(0.U)
 
         c.inc()
 
@@ -71,6 +74,10 @@ object ToyDUT {
             aHasEqb := 1.U
         }
 
+        when(c.value > io.b) {
+            cSupb := 1.U
+        }
+
         //Set outputs
         io.aEqb := (aWire === io.b).asUInt()
         io.aNevEqb := (aHasEqb === 0.U).asUInt()
@@ -79,5 +86,7 @@ object ToyDUT {
         io.outA := io.a
         io.outB := io.b
         io.outC := c.value
+        io.outCSupB := io.b + cSupb
+        io.outCNotSupB := io.b - cSupb
     }
 }

--- a/src/test/scala/verifyTests/assertions/TimedAssertionTests.scala
+++ b/src/test/scala/verifyTests/assertions/TimedAssertionTests.scala
@@ -4,7 +4,7 @@ import chisel3._
 import chisel3.tester._
 import chiseltest.ChiselScalatestTester
 import chiselverify.assertions.{AssertTimed, ExpectTimed}
-import chiselverify.timing.TimedOp.Equals
+import chiselverify.timing.TimedOp.{Equals, Gt}
 import chiselverify.timing._
 import org.scalatest.{FlatSpec, Matchers}
 import verifyTests.ToyDUT.AssertionsToyDUT
@@ -94,6 +94,50 @@ class TimedAssertionTests extends FlatSpec with ChiselScalatestTester with Match
         }
     }
 
+    def testGenericGtOp[T <: AssertionsToyDUT](dut: T, et : EventType): Unit = {
+
+        /**
+          * Basic test to see if we get the right amount of hits
+          */
+        def testAlways(): Unit = {
+            dut.io.a.poke(20.U)
+            dut.io.b.poke(10.U)
+            dut.clock.step(1)
+            println(s"aEqb is ${dut.io.aEqb.peek().litValue()}")
+            AssertTimed(dut, Gt(dut.io.outA, dut.io.outB), "a isn't always superior to one")(Always(9)).join()
+        }
+
+        def testEventually(): Unit = {
+            dut.io.a.poke(4.U)
+            dut.io.b.poke(2.U)
+            dut.clock.step()
+            AssertTimed(dut, Gt(dut.io.outB, dut.io.outCNotSupB), "c isn't eventually greater than b")(Eventually(4)).join()
+        }
+
+        def testExactly(): Unit = {
+            dut.io.a.poke(6.U)
+            dut.io.b.poke(5.U)
+            dut.clock.step(2)
+            println(s"C = ${dut.io.outC.peek().litValue()}")
+
+            AssertTimed(dut, Gt(dut.io.outB, dut.io.outCNotSupB), "c isn't greater than b after 7 cycles")(Exactly(7)).join()
+        }
+
+        def testNever(): Unit = {
+            dut.io.a.poke(10.U)
+            dut.io.b.poke(20.U)
+            dut.clock.step(1)
+            AssertTimed(dut, Gt(dut.io.outC, dut.io.outA), "a is equal to b at some point")(Never(10)).join()
+        }
+
+        et match {
+            case Always => testAlways()
+            case Eventually => testEventually()
+            case Exactly => testExactly()
+            case Never => testNever()
+        }
+    }
+
     "Timed Assertions Always" should "pass" in {
         test(new AssertionsToyDUT(32)){ dut => testGeneric(dut, Always) }
     }
@@ -106,6 +150,7 @@ class TimedAssertionTests extends FlatSpec with ChiselScalatestTester with Match
     "Timed Assertions Never" should "pass" in {
         test(new AssertionsToyDUT(32)){ dut => testGeneric(dut, Never) }
     }
+
     "Timed Assertions Always with Equals Op" should "pass" in {
         test(new AssertionsToyDUT(32)){dut => testGenericEqualsOp(dut, Always)}
     }
@@ -117,5 +162,18 @@ class TimedAssertionTests extends FlatSpec with ChiselScalatestTester with Match
     }
     "Timed Assertions Never with Equals Op" should "pass" in {
         test(new AssertionsToyDUT(32)){ dut => testGenericEqualsOp(dut, Never) }
+    }
+
+    "Timed Assertions Always with GreaterThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){dut => testGenericGtOp(dut, Always)}
+    }
+    "Timed Assertions Eventually with GreaterThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericGtOp(dut, Eventually) }
+    }
+    "Timed Assertions Exactly with GreaterThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericGtOp(dut, Exactly) }
+    }
+    "Timed Assertions Never with GreaterThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericGtOp(dut, Never) }
     }
 }

--- a/src/test/scala/verifyTests/assertions/TimedAssertionTests.scala
+++ b/src/test/scala/verifyTests/assertions/TimedAssertionTests.scala
@@ -4,7 +4,7 @@ import chisel3._
 import chisel3.tester._
 import chiseltest.ChiselScalatestTester
 import chiselverify.assertions.{AssertTimed, ExpectTimed}
-import chiselverify.timing.TimedOp.{Equals, Gt}
+import chiselverify.timing.TimedOp.{Equals, Gt, GtEq, Lt, LtEq}
 import chiselverify.timing._
 import org.scalatest.{FlatSpec, Matchers}
 import verifyTests.ToyDUT.AssertionsToyDUT
@@ -138,6 +138,138 @@ class TimedAssertionTests extends FlatSpec with ChiselScalatestTester with Match
         }
     }
 
+    def testGenericLtOp[T <: AssertionsToyDUT](dut: T, et : EventType): Unit = {
+
+        /**
+          * Basic test to see if we get the right amount of hits
+          */
+        def testAlways(): Unit = {
+            dut.io.a.poke(10.U)
+            dut.io.b.poke(20.U)
+            dut.clock.step(1)
+            println(s"aEqb is ${dut.io.aEqb.peek().litValue()}")
+            AssertTimed(dut, Lt(dut.io.outA, dut.io.outB), "a isn't always less than one")(Always(9)).join()
+        }
+
+        def testEventually(): Unit = {
+            dut.io.a.poke(4.U)
+            dut.io.b.poke(2.U)
+            dut.clock.step()
+            AssertTimed(dut, Lt(dut.io.outB, dut.io.outCSupB), "c isn't eventually less than b")(Eventually(4)).join()
+        }
+
+        def testExactly(): Unit = {
+            dut.io.a.poke(6.U)
+            dut.io.b.poke(5.U)
+            dut.clock.step(2)
+            println(s"C = ${dut.io.outC.peek().litValue()}")
+
+            AssertTimed(dut, Lt(dut.io.outB, dut.io.outCSupB), "c isn't less than b after 7 cycles")(Exactly(7)).join()
+        }
+
+        def testNever(): Unit = {
+            dut.io.a.poke(10.U)
+            dut.io.b.poke(20.U)
+            dut.clock.step(1)
+            AssertTimed(dut, Lt(dut.io.outB, dut.io.outCNotSupB), "a is never less than c at any point")(Never(10)).join()
+        }
+
+        et match {
+            case Always => testAlways()
+            case Eventually => testEventually()
+            case Exactly => testExactly()
+            case Never => testNever()
+        }
+    }
+
+    def testGenericLtEqOp[T <: AssertionsToyDUT](dut: T, et : EventType): Unit = {
+
+        /**
+          * Basic test to see if we get the right amount of hits
+          */
+        def testAlways(): Unit = {
+            dut.io.a.poke(10.U)
+            dut.io.b.poke(20.U)
+            dut.clock.step(1)
+            println(s"aEqb is ${dut.io.aEqb.peek().litValue()}")
+            AssertTimed(dut, LtEq(dut.io.outA, dut.io.outB), "a isn't always less than one")(Always(9)).join()
+        }
+
+        def testEventually(): Unit = {
+            dut.io.a.poke(4.U)
+            dut.io.b.poke(2.U)
+            dut.clock.step()
+            AssertTimed(dut, LtEq(dut.io.outB, dut.io.outCSupB), "c isn't eventually less than b")(Eventually(4)).join()
+        }
+
+        def testExactly(): Unit = {
+            dut.io.a.poke(6.U)
+            dut.io.b.poke(5.U)
+            dut.clock.step(2)
+            println(s"C = ${dut.io.outC.peek().litValue()}")
+
+            AssertTimed(dut, LtEq(dut.io.outB, dut.io.outCSupB), "c isn't less than b after 7 cycles")(Exactly(7)).join()
+        }
+
+        def testNever(): Unit = {
+            dut.io.a.poke(10.U)
+            dut.io.b.poke(11.U)
+            dut.clock.step(1)
+            AssertTimed(dut, LtEq(dut.io.outB, dut.io.outC), "a is never less than c at any point")(Never(10)).join()
+        }
+
+        et match {
+            case Always => testAlways()
+            case Eventually => testEventually()
+            case Exactly => testExactly()
+            case Never => testNever()
+        }
+    }
+
+    def testGenericGtEqOp[T <: AssertionsToyDUT](dut: T, et : EventType): Unit = {
+
+        /**
+          * Basic test to see if we get the right amount of hits
+          */
+        def testAlways(): Unit = {
+            dut.io.a.poke(10.U)
+            dut.io.b.poke(20.U)
+            dut.clock.step(1)
+            println(s"aEqb is ${dut.io.aEqb.peek().litValue()}")
+            AssertTimed(dut, GtEq(dut.io.outB, dut.io.outA), "a isn't always less than one")(Always(9)).join()
+        }
+
+        def testEventually(): Unit = {
+            dut.io.a.poke(4.U)
+            dut.io.b.poke(2.U)
+            dut.clock.step()
+            AssertTimed(dut, GtEq(dut.io.outB, dut.io.outCNotSupB), "c isn't eventually less than b")(Eventually(4)).join()
+        }
+
+        def testExactly(): Unit = {
+            dut.io.a.poke(6.U)
+            dut.io.b.poke(5.U)
+            dut.clock.step(2)
+            println(s"C = ${dut.io.outC.peek().litValue()}")
+
+            AssertTimed(dut, GtEq(dut.io.outB, dut.io.outCNotSupB), "c isn't less than b after 7 cycles")(Exactly(7)).join()
+        }
+
+        def testNever(): Unit = {
+            dut.io.a.poke(10.U)
+            dut.io.b.poke(0.U)
+            dut.clock.step(1)
+            AssertTimed(dut, GtEq(dut.io.outB, dut.io.outC), "a is never less than c at any point")(Never(10)).join()
+        }
+
+        et match {
+            case Always => testAlways()
+            case Eventually => testEventually()
+            case Exactly => testExactly()
+            case Never => testNever()
+        }
+    }
+
     "Timed Assertions Always" should "pass" in {
         test(new AssertionsToyDUT(32)){ dut => testGeneric(dut, Always) }
     }
@@ -175,5 +307,44 @@ class TimedAssertionTests extends FlatSpec with ChiselScalatestTester with Match
     }
     "Timed Assertions Never with GreaterThan Op" should "pass" in {
         test(new AssertionsToyDUT(32)){ dut => testGenericGtOp(dut, Never) }
+    }
+
+    "Timed Assertions Always with LessThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){dut => testGenericLtOp(dut, Always)}
+    }
+    "Timed Assertions Eventually with LessThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericLtOp(dut, Eventually) }
+    }
+    "Timed Assertions Exactly with LessThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericLtOp(dut, Exactly) }
+    }
+    "Timed Assertions Never with LessThan Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericLtOp(dut, Never) }
+    }
+
+    "Timed Assertions Always with LessThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){dut => testGenericLtEqOp(dut, Always)}
+    }
+    "Timed Assertions Eventually with LessThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericLtEqOp(dut, Eventually) }
+    }
+    "Timed Assertions Exactly with LessThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericLtEqOp(dut, Exactly) }
+    }
+    "Timed Assertions Never with LessThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericLtEqOp(dut, Never) }
+    }
+
+    "Timed Assertions Always with GreaterThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){dut => testGenericGtEqOp(dut, Always)}
+    }
+    "Timed Assertions Eventually with GreaterThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericGtEqOp(dut, Eventually) }
+    }
+    "Timed Assertions Exactly with GreaterThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericGtEqOp(dut, Exactly) }
+    }
+    "Timed Assertions Never with GreaterThan or Equal to Op" should "pass" in {
+        test(new AssertionsToyDUT(32)){ dut => testGenericGtEqOp(dut, Never) }
     }
 }


### PR DESCRIPTION
This PR is a continuation of PR #23. 
Here a new `Cover` construct called `TimedCoverOp` has been created and has the following signature:  
```scala
case class TimedCoverOp(pN: String, op: TimedOperator)(val delay: DelayType)
```  
This can then be simply used along-side the `TimedOperations` introduced in #23, to define a cover construct similar to a `TimedCross` but where the two operators aren't only sampled on the same cycle.  

This construct supports the following delay types:  
- `Exactly`: Operand 1 is compared to operand 2 sampled `delay` cycles later. A hit is only considered if the operation is satisfied at the specific cycle.  
- `Eventually`: Operand 1 is compared to operand 2 at every cycle for the current and the following `delay` cycles. A hit is considered if the operation is satisfied at least once during those cycles.  
- `Always`: Operand 1 is compared to operand 2 at every cycle for the current and the following `delay` cycles. A hit is considered if the operation is satisfied at every one of those cycles.    

